### PR TITLE
Include the enum Python module.

### DIFF
--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -10,6 +10,7 @@ RUN yum -y install epel-release && yum -y install \
   git \
   python-pep8 \
   python2-pip \
+  python2-enum \
   python-devel \
   hdf5-openmpi-devel \
   zlib-devel \

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
     openmpi-bin \
     libfftw3-dev \
     libboost-dev libboost-serialization-dev libboost-mpi-dev libboost-filesystem-dev libboost-test-dev \
-    python python-numpy python-pyvtk python-h5py\
+    python python-numpy python-pyvtk python-h5py python-enum\
     lcov \
     git \
     pep8 \

--- a/docker/opensuse/Dockerfile
+++ b/docker/opensuse/Dockerfile
@@ -7,7 +7,7 @@ RUN zypper -n --gpg-auto-import-keys refresh \
   openmpi-devel Modules \
   fftw3-devel \
   boost-devel libboost_serialization1_54_0 libboost_mpi1_54_0  libboost_filesystem1_54_0 libboost_test1_54_0 \
-  python python-numpy python-numpy-devel python-h5py \
+  python python-numpy python-numpy-devel python-h5py python-enum34 \
   git \
   python-pep8 \
   python-pip \

--- a/docker/ubuntu-cuda/Dockerfile
+++ b/docker/ubuntu-cuda/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
     openmpi-bin \
     libfftw3-dev \
     libboost-dev libboost-serialization-dev libboost-mpi-dev libboost-filesystem-dev libboost-test-dev \
-    python python-numpy python-h5py \
+    python python-numpy python-h5py python-enum \
     git \
     pep8 \
     python-pyvtk \

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
     openmpi-bin \
     libfftw3-dev \
     libboost-dev libboost-serialization-dev libboost-mpi-dev libboost-filesystem-dev libboost-test-dev \
-    cython python python-numpy python-h5py \
+    cython python python-numpy python-h5py python-enum \
     lcov \
     curl \
     git \


### PR DESCRIPTION
In preparation for collision detection support in Pypresso.

Python3-containers don't need it, since Py3 seems to include this by default.