### PR TITLE
Fix segfaulting CI tests when CUDA is enabled

### DIFF
--- a/docker/ubuntu-cuda/Dockerfile
+++ b/docker/ubuntu-cuda/Dockerfile
@@ -20,7 +20,8 @@ RUN apt-get update && apt-get install -y \
     vim \
 && pip2 install cython sphinx sphinxcontrib-bibtex numpydoc --upgrade \
 && apt-get clean \
-&& rm -rf /var/lib/apt/lists/*
+&& rm -rf /var/lib/apt/lists/* \
+&& rm /usr/lib/pymodules/python2.7/vtk/vtk{Rendering,VolumeRendering,Hybrid,Widgets,Charts,Geovis,Infovis,TextAnalysis,Views,Parallel}Python.so
 
 RUN cd /usr/local \
 && curl -sL https://cmake.org/files/v3.1/cmake-3.1.0-Linux-x86_64.tar.gz | tar --strip-components=1 -xz


### PR DESCRIPTION
As reported by @KaiSzuttor, on the evening of November 9th, CI tests started failing when run on a Docker container with Nvidia GPUs. It seems like vtkRenderingPython now attempts to use the GPU for rendering, which fails. This pull request just deletes the optional VTK modules that were responsible for this. See below for the full debug info.

```
$ gdb python
(gdb) run -c 'import vtk'
Program received signal SIGSEGV, Segmentation fault.
0x00007ffff786db88 in __GI__IO_un_link (fp=0xa70bb0) at genops.c:65
(gdb) py-bt
#9 Frame 0x7ffff7e885c0, for file /usr/lib/pymodules/python2.7/vtk/__init__.py, line 60, in <module> ()
    from vtkRenderingPython import *
#24 Frame 0x7ffff7fcdc20, for file <string>, line 1, in <module> ()
Python Exception <class 'FileNotFoundError'> [Errno 2] No such file or directory: '<string>': 
Error occurred in Python command: [Errno 2] No such file or directory: '<string>'
(gdb) bt
#0  0x00007ffff786db88 in __GI__IO_un_link (fp=0xa70bb0) at genops.c:65
#1  0x00007ffff7860a65 in _IO_new_fclose (fp=0xa70bb0) at iofclose.c:55
#2  0x000000000055644f in import_submodule.39248 (mod=mod@entry=<module at remote 0x7ffff7e9d7c0>, 
    subname=subname@entry=0x9fc414 "vtkRenderingPython", fullname=0x9fc410 "vtk.vtkRenderingPython")
    at ../Python/import.c:2703
[...]
(gdb) py-list
  55        kits.append('genericfiltering')
  56    except ImportError, exc:
  57        __helper.refine_import_err('genericfiltering', 'vtkGenericFilteringPython',
  58                                   exc)
  59    try:
 >60        from vtkRenderingPython import *
  61        kits.append('rendering')
  62    except ImportError, exc:
  63        __helper.refine_import_err('rendering', 'vtkRenderingPython', exc)
  64    
  65    try:
```

I have no idea what changed, but here are a few things that can't be blamed:
- We upgraded to nvidia-384 drivers on October 24th. Things still worked after that as far as I can tell.
- We disabled the use of the Nvidia GPUs on the CIP pool machines for graphics on November 10th via `sudo prime-select intel`. However, I can reproduce the segfault on my desktop machine too, which doesn't have an Intel GPU.
- The Docker image was rebuilt six days ago. Everything still worked for three days before the error started popping up.