### PR TITLE
Ubuntu-CUDA: upgrade CMake to 3.8

### DIFF
--- a/docker/ubuntu-clang-cuda/Dockerfile
+++ b/docker/ubuntu-clang-cuda/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install -y \
 && rm -rf /var/lib/apt/lists/*
 
 RUN cd /usr/local \
-&& curl -sL https://cmake.org/files/v3.6/cmake-3.6.3-Linux-x86_64.tar.gz | tar --strip-components=1 -xz
+&& curl -sL https://cmake.org/files/v3.8/cmake-3.8.2-Linux-x86_64.tar.gz | tar --strip-components=1 -xz
 
 RUN cd /usr/src && \
     git clone https://github.com/thrust/thrust.git && \


### PR DESCRIPTION
Follow-up to #11, which https://github.com/espressomd/espresso/pull/1683 depends on. The newer version is needed because without https://github.com/Kitware/CMake/commit/80ebc55a7ce934ee357c30713bcb96b209e97963, clang-tidy errors are silently ignored.