### PR TITLE
More clang-tidy fixes for Boost MPI

### DIFF
--- a/docker/ubuntu-clang-cuda/boost.patch
+++ b/docker/ubuntu-clang-cuda/boost.patch
@@ -11,6 +11,42 @@ diff -ru boost/mpi/collectives/all_reduce.hpp boost/mpi/collectives/all_reduce.h
      BOOST_MPI_CHECK_RESULT(MPI_Allreduce,
                             (const_cast<T*>(in_values), out_values, n,
                              boost::mpi::get_mpi_datatype<T>(*in_values),
+diff -ru /tmp/boost/mpi/collectives/reduce.hpp /usr/include/boost/mpi/collectives/reduce.hpp
+--- boost/mpi/collectives/reduce.hpp	2018-01-08 12:24:08.143526811 +0100
++++ boost/mpi/collectives/reduce.hpp	2018-01-08 12:27:01.368661956 +0100
+@@ -81,7 +81,8 @@
+               T* out_values, Op op, int root, mpl::false_ /*is_mpi_op*/,
+               mpl::true_/*is_mpi_datatype*/)
+   {
+-    user_op<Op, T> mpi_op(op);
++    static Op lop = op;
++    user_op<Op, T> mpi_op(lop);
+     BOOST_MPI_CHECK_RESULT(MPI_Reduce,
+                            (const_cast<T*>(in_values), out_values, n,
+                             boost::mpi::get_mpi_datatype<T>(*in_values),
+@@ -96,7 +97,8 @@
+   reduce_impl(const communicator& comm, const T* in_values, int n, Op op, 
+               int root, mpl::false_/*is_mpi_op*/, mpl::true_/*is_mpi_datatype*/)
+   {
+-    user_op<Op, T> mpi_op(op);
++    static Op lop = op;
++    user_op<Op, T> mpi_op(lop);
+     BOOST_MPI_CHECK_RESULT(MPI_Reduce,
+                            (const_cast<T*>(in_values), 0, n,
+                             boost::mpi::get_mpi_datatype<T>(*in_values),
+diff -ru /tmp/boost/mpi/collectives/scan.hpp /usr/include/boost/mpi/collectives/scan.hpp
+--- boost/mpi/collectives/scan.hpp	2018-01-08 12:24:08.143526811 +0100
++++ boost/mpi/collectives/scan.hpp	2018-01-08 12:28:38.185296393 +0100
+@@ -67,7 +67,8 @@
+   scan_impl(const communicator& comm, const T* in_values, int n, T* out_values,
+             Op op, mpl::false_ /*is_mpi_op*/, mpl::true_ /*is_mpi_datatype*/)
+   {
+-    user_op<Op, T> mpi_op(op);
++    static Op lop = op;
++    user_op<Op, T> mpi_op(lop);
+     BOOST_MPI_CHECK_RESULT(MPI_Scan,
+                            (const_cast<T*>(in_values), out_values, n,
+                             boost::mpi::get_mpi_datatype<T>(*in_values),
 diff -ru boost/mpi/collectives/scatter.hpp boost/mpi/collectives/scatter.hpp
 --- boost/mpi/collectives/scatter.hpp	2017-12-20 14:26:58.079548000 +0100
 +++ boost/mpi/collectives/scatter.hpp	2017-12-20 15:07:44.242734024 +0100


### PR DESCRIPTION
One last fix needed for https://github.com/espressomd/espresso/pull/1683