### PR TITLE
Patch out __THRUST_SYNCHRONOUS broken in Thrust < 1.9

### DIFF
--- a/docker/ubuntu-cuda/Dockerfile
+++ b/docker/ubuntu-cuda/Dockerfile
@@ -26,6 +26,9 @@ RUN apt-get update && apt-get install -y \
 RUN cd /usr/local \
 && curl -sL https://cmake.org/files/v3.1/cmake-3.1.0-Linux-x86_64.tar.gz | tar --strip-components=1 -xz
 
+COPY thrust.patch /tmp/
+RUN cd /usr/local/cuda/include/thrust && patch -p1 < /tmp/thrust.patch
+
 RUN useradd -m espresso && usermod -a -G www-data espresso
 USER espresso
 WORKDIR /home/espresso

--- a/docker/ubuntu-cuda/thrust.patch
+++ b/docker/ubuntu-cuda/thrust.patch
@@ -1,0 +1,17 @@
+--- thrust/system/cuda/detail/bulk/detail/synchronize.hpp	2017-10-19 10:57:38.732756117 +0200
++++ thrust/system/cuda/detail/bulk/detail/synchronize.hpp	2018-01-15 09:54:49.375321978 +0100
+@@ -44,14 +44,8 @@
+ inline __host__ __device__
+ void synchronize_if_enabled(const char* message = "")
+ {
+-// XXX we rely on __THRUST_SYNCHRONOUS here
+-//     note we always have to synchronize in __device__ code
+-#if __THRUST_SYNCHRONOUS || defined(__CUDA_ARCH__)
+-  synchronize(message);
+-#else
+   // WAR "unused parameter" warning
+   (void) message;
+-#endif
+ }
+ 
+ 


### PR DESCRIPTION
Really fixes https://github.com/espressomd/espresso/issues/1596 after @RudolfWeeber ran into it again.