### PR TITLE
One more thrust patch

### DIFF
--- a/docker/ubuntu-cuda/thrust.patch
+++ b/docker/ubuntu-cuda/thrust.patch
@@ -66,3 +66,15 @@
  void synchronize_if_enabled(const char *message)
  {
  // XXX this could potentially be a runtime decision
+
+--- thrust/system/cuda/detail/bulk/detail/cuda_launcher/cuda_launcher.hpp	2017-10-19 10:57:38.744755827 +0200
++++ thrust/system/cuda/detail/bulk/detail/cuda_launcher/cuda_launcher.hpp	2018-01-19 15:37:32.828072280 +0100
+@@ -70,8 +70,6 @@
+     if(num_blocks > 0)
+     {
+       super_t::launch(num_blocks, block_size, num_dynamic_smem_bytes, stream, task);
+-
+-      bulk::detail::synchronize_if_enabled("bulk_kernel_by_value");
+     } // end if
+   } // end launch()
+ 


### PR DESCRIPTION
All this patchwork is getting annoying, but this one suppresses the warning that was seen in https://gitlab.icp.uni-stuttgart.de/espressomd/espresso/-/jobs/8694 while building https://github.com/espressomd/espresso/pull/1769:
```
/usr/local/cuda/include/thrust/system/cuda/detail/bulk/detail/cuda_launcher/cuda_launcher.hpp(74): warning: calling a __host__ function from a __host__ __device__ function is not allowed
```

It seems like all these things are fixed already in Thrust 1.9, but I can't just backport the fix from there because all the synchronization code was essentially rewritten. And I don't want to upgrade to Thrust 1.9 because then we might not notice if we ever break CUDA 8 compatibility. The Clang-CUDA build is using some Thrust 1.8.x prerelease though and it didn't have any of the issues that I've been trying to fix over the past few days, but mostly because Clang is different than NVCC...