### PR TITLE
Ubuntu: Include scafacos library incl dipoles

### DIFF
--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -1,13 +1,17 @@
 FROM ubuntu:xenial
 MAINTAINER Florian Weik <fweik@icp.uni-stuttgart.de>
 ENV DEBIAN_FRONTEND noninteractive
+COPY build-and-install-scafacos.sh /tmp
 RUN apt-get update && apt-get install -y \
     apt-utils \
     cmake \
     build-essential \
-    openmpi-bin \
+    pkg-config \
+    openmpi-bin libopenmpi-dev \
+    gfortran \
     libfftw3-dev \
     libboost-dev libboost-serialization-dev libboost-mpi-dev libboost-filesystem-dev libboost-test-dev \
+    libgsl-dev \
     cython python python-numpy python-h5py python-enum \
     lcov \
     curl \
@@ -18,9 +22,12 @@ RUN apt-get update && apt-get install -y \
     libhdf5-openmpi-dev \
     libhdf5-openmpi-10:amd64 \
     libhdf5-10:amd64 \
+    autoconf automake \
     vim \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/*
+
+RUN bash /tmp/build-and-install-scafacos.sh
 
 RUN useradd -m espresso
 USER espresso

--- a/docker/ubuntu/build-and-install-scafacos.sh
+++ b/docker/ubuntu/build-and-install-scafacos.sh
@@ -1,0 +1,13 @@
+cd /tmp &&
+git clone git://github.com/RudolfWeeber/scafacos --branch for_use_with_espresso_dipoles &&
+cd scafacos &&
+git submodule init &&
+git submodule update &&
+./bootstrap &&
+./configure --with-internal-pfft --with-internal-pnfft --enable-fcs-solvers=direct,pnfft,p2nfft,p3m --enable-shared --disable-fcs-fortran &&
+make -j `nproc` &&
+make install &&
+cd &&
+rm -rf /tmp/scafacos &&
+ldconfig
+


### PR DESCRIPTION
Until https://github.com/scafacos/scafacos/issues/26 on scafacos is resolved, this pulls a custom version of scafacos.
It is the parent of the commit which likely introduces the regression and has additional changes chery-picked which silence debug output.