### PR TITLE
Switch from pep8 to pycodestyle

### DIFF
--- a/docker/ubuntu-python3/Dockerfile-18.04
+++ b/docker/ubuntu-python3/Dockerfile-18.04
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
     cython3 python3 python3-numpy python3-h5py \
     lcov \
     git \
-    pep8 pylint3 \
+    pycodestyle pylint3 \
     python3-vtk7 \
     libhdf5-openmpi-dev \
     libhdf5-openmpi-100:amd64 \

--- a/docker/ubuntu/Dockerfile-18.04
+++ b/docker/ubuntu/Dockerfile-18.04
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y \
     lcov \
     curl \
     git \
-    pep8 pylint \
+    pycodestyle pylint \
     python-vtk6 \
     python-pyface \
     libhdf5-openmpi-dev \


### PR DESCRIPTION
Fixes #39.

In Ubuntu 18.04, pep8 was only a transitional package for pycodestyle anyway. SUSE 15 uses pycodestyle already. All other images also use pep8 from the repository and not from pip, so they do not require any action until they are upgraded to newer distribution versions.