### PR TITLE
rocm: fix rocfft install

### DIFF
--- a/docker/rocm/Dockerfile-latest
+++ b/docker/rocm/Dockerfile-latest
@@ -34,7 +34,7 @@ RUN cd /tmp \
  && cp -r Thrust-6e31840ed4ac5e158e485c5cc22558a601a86ae8/thrust /opt/rocm/include/ \
  && rm -r Thrust-6e31840ed4ac5e158e485c5cc22558a601a86ae8
 
-RUN apt-get remove -y rocfft \
+RUN sync && apt-get remove -y rocfft \
  && cd /tmp \
  && git clone -b r2c https://github.com/mkuron/rocFFT.git \
  && cd rocFFT \


### PR DESCRIPTION
Fix https://gitlab.icp.uni-stuttgart.de/espressomd/docker/-/jobs/51864

```
Removing rocfft (0.8.6.0) ...
dpkg (subprocess): unable to execute installed pre-removal script (/var/lib/dpkg/info/rocfft.prerm): Text file busy
dpkg: error processing package rocfft (--remove):
 subprocess installed pre-removal script returned error exit status 2
```