### PR TITLE
ROCm 2.0

### DIFF
--- a/docker/rocm/Dockerfile-latest
+++ b/docker/rocm/Dockerfile-latest
@@ -22,21 +22,9 @@ RUN apt-get update && apt-get install -y \
     libhdf5-10:amd64 \
     vim \
     ccache \
-    rocrand \
+    rocrand rocfft hip-thrust \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/*
-
-RUN cd /tmp \
- && curl -Ls https://github.com/ROCmSoftwarePlatform/Thrust/archive/6e31840.tar.gz | tar xz \
- && cp -r Thrust-6e31840ed4ac5e158e485c5cc22558a601a86ae8/thrust /opt/rocm/include/ \
- && rm -r Thrust-6e31840ed4ac5e158e485c5cc22558a601a86ae8
-
-RUN cd /tmp \
- && curl -Ls https://github.com/ROCmSoftwarePlatform/rocFFT/archive/f024b94.tar.gz | tar xz \
- && cd rocFFT-* \
- && mkdir build && cd build \
- && CXX=/opt/rocm/bin/hcc cmake .. && make -j 4 install \
- && cd ../.. && rm -r rocFFT-*
 
 RUN useradd -m espresso
 USER espresso


### PR DESCRIPTION
The new version includes https://github.com/ROCmSoftwarePlatform/rocFFT/pull/141 and provides a Thrust package