### PR TITLE
Require CUDA-capable runners for tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,6 +35,7 @@ stages:
   tags:
     - docker
     - linux
+    - cuda
 
 .test_py3_template: &test_py3_definition
   <<: *test_definition


### PR DESCRIPTION
Fixes https://gitlab.icp.uni-stuttgart.de/espressomd/docker/-/jobs/74070

```
ERROR: Job failed (system failure): Error response from daemon: OCI runtime create failed: container_linux.go:344: starting container process caused "process_linux.go:424: container init caused \"process_linux.go:407: running prestart hook 1 caused \\\"error running hook: exit status 1, stdout: , stderr: exec command: [/usr/bin/nvidia-container-cli --load-kmods configure --ldconfig=@/sbin/ldconfig.real --device=all --compute --utility --require=cuda>=10.0 brand=tesla,driver>=384,driver<385 --pid=2701051 /scratch/docker/aufs/mnt/f17dee4067e279d2214d751db70460815f09324318c51c9ea593534bd9210f7a]\\\\nnvidia-container-cli: requirement error: unsatisfied condition: brand = tesla\\\\n\\\"\"": unknown (executor_docker.go:1018:1s)
```