### PR TITLE
Update containers: Scafacos, 4.0.2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,7 @@ stages:
   script:
     - git clone --recursive https://github.com/espressomd/espresso
     - cd espresso
-    - git checkout 4.0.1
+    - git checkout 4.0
     - maintainer/CI/build_cmake.sh
   variables:
     make_check: "false"

--- a/docker/ubuntu-python3/Dockerfile-18.04
+++ b/docker/ubuntu-python3/Dockerfile-18.04
@@ -1,13 +1,17 @@
 FROM ubuntu:bionic
 MAINTAINER Florian Weik <fweik@icp.uni-stuttgart.de>
 ENV DEBIAN_FRONTEND noninteractive
+COPY build-and-install-scafacos.sh /tmp
 RUN apt-get update && apt-get install -y \
     apt-utils \
     cmake \
     build-essential \
-    openmpi-bin \
+    pkg-config \
+    openmpi-bin libopenmpi-dev \
+    gfortran \
     libfftw3-dev \
     libboost-dev libboost-serialization-dev libboost-mpi-dev libboost-filesystem-dev libboost-test-dev \
+    libgsl-dev \
     cython3 python3 python3-numpy python3-h5py \
     lcov \
     git \
@@ -16,15 +20,16 @@ RUN apt-get update && apt-get install -y \
     libhdf5-openmpi-dev \
     libhdf5-openmpi-100:amd64 \
     libhdf5-100:amd64 \
+    autoconf \
     vim \
     ccache \
     curl \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/*
+RUN bash /tmp/build-and-install-scafacos.sh
 RUN useradd -m espresso
 USER 1000
 run cd /home/espresso && \
-  git clone https://gitlab.icp.uni-stuttgart.de/espressomd/walberla_for_es walberla && \
+  git clone https://gitlab.icp.uni-stuttgart.de/espressomd/walberla_for_es.git walberla && \
   cd walberla && cmake .
 WORKDIR /home/espresso
-

--- a/docker/ubuntu-python3/build-and-install-scafacos.sh
+++ b/docker/ubuntu-python3/build-and-install-scafacos.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+cd /tmp
+git clone --recursive git://github.com/scafacos/scafacos --branch dipoles
+cd scafacos
+./bootstrap
+./configure --enable-shared \
+	--with-internal-pfft --with-internal-pnfft \
+	--enable-fcs-solvers=direct,pnfft,p2nfft,p3m \
+	--disable-fcs-fortran --enable-fcs-dipoles
+make -j `nproc`
+make install
+cd
+rm -rf /tmp/scafacos
+ldconfig


### PR DESCRIPTION
* Transfer Scafacos from Ubuntu 18 Python 2 to Ubuntu 18 Python 3 (espressomd/espresso#2694)
* Test 4.0.x-specific containers against the 4.0 branch, which was recently fast-forwarded to 4.0.2