### PR TITLE
Switch docker build to kaniko

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,3 @@
-image: docker:latest
-
 stages:
   - build
   - test
@@ -7,14 +5,17 @@ stages:
 
 .build_template: &build_definition
   stage: build
+  image:
+    name: gcr.io/kaniko-project/executor:debug
+    entrypoint: [""]
   before_script:
-    - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
-    - docker pull $CI_REGISTRY/$CI_PROJECT_PATH/$CI_JOB_NAME || true
+    - echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_REGISTRY_USER\",\"password\":\"$CI_REGISTRY_PASSWORD\"}}}" > /kaniko/.docker/config.json
   script:
     - sh maintainer/docker_build.sh
   tags:
-    - docker-docker
+    - docker
     - linux
+    - nofirewall
 
 .test_template: &test_definition
   stage: test
@@ -29,15 +30,13 @@ stages:
   tags:
     - docker
     - linux
-    - cuda
 
 .test_template: &test_v40_definition
   stage: test
   image: $CI_REGISTRY/$CI_PROJECT_PATH/$CI_JOB_NAME-$CI_COMMIT_SHA
   script:
-    - git clone --recursive https://github.com/espressomd/espresso
+    - git clone -b 4.0 --recursive https://github.com/espressomd/espresso
     - cd espresso
-    - git checkout 4.0
     - maintainer/CI/build_cmake.sh
   variables:
     make_check: "false"
@@ -45,7 +44,6 @@ stages:
   tags:
     - docker
     - linux
-    - cuda
 
 .test_py3_template: &test_py3_definition
   <<: *test_definition
@@ -82,8 +80,18 @@ rocm:latest:
   <<: *build_definition
 intel:15:
   <<: *build_definition
+  tags:
+    - docker
+    - linux
+    - nofirewall
+    - icp
 intel:18:
   <<: *build_definition
+  tags:
+    - docker
+    - linux
+    - nofirewall
+    - icp
 ubuntu-python3:16.04:
   <<: *build_definition
 ubuntu-python3:18.04:
@@ -128,8 +136,16 @@ test/rocm:latest:
     HCC_AMDGPU_TARGET: "gfx900"
 test/intel:15:
   <<: *test_v40_definition
+  tags:
+    - docker
+    - linux
+    - icp
 test/intel:18:
   <<: *test_definition
+  tags:
+    - docker
+    - linux
+    - icp
 test/ubuntu-python3:16.04:
   <<: *test_py3_definition
 test/ubuntu-python3:18.04:

--- a/docker/clang/Dockerfile-4.0
+++ b/docker/clang/Dockerfile-4.0
@@ -27,7 +27,8 @@ RUN apt-get update && apt-get install -y \
 && rm -rf /var/lib/apt/lists/*
 
 RUN cd /usr/local \
-&& curl -sL https://cmake.org/files/v3.8/cmake-3.8.2-Linux-x86_64.tar.gz | tar --strip-components=1 -xz
+&& curl -sL https://cmake.org/files/v3.8/cmake-3.8.2-Linux-x86_64.tar.gz | tar --strip-components=1 -xz \
+&& rm -r /usr/local/man
 
 RUN cd /usr/src && \
     git clone https://github.com/thrust/thrust.git && \

--- a/docker/clang/Dockerfile-6.0
+++ b/docker/clang/Dockerfile-6.0
@@ -39,7 +39,8 @@ RUN cd /tmp \
  && rm -r /tmp/ccache-3.4.3
 
 RUN cd /usr/local \
-&& curl -sL https://cmake.org/files/v3.8/cmake-3.8.2-Linux-x86_64.tar.gz | tar --strip-components=1 -xz
+&& curl -sL https://cmake.org/files/v3.8/cmake-3.8.2-Linux-x86_64.tar.gz | tar --strip-components=1 -xz \
+&& rm -r /usr/local/man
 
 RUN cd /usr/src && \
     git clone https://github.com/thrust/thrust.git && \

--- a/docker/intel/Dockerfile-15
+++ b/docker/intel/Dockerfile-15
@@ -34,7 +34,7 @@ RUN cd /tmp \
  && curl -sL http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/4933/l_compxe_2015.1.133.tgz | tar --strip-components=1 -xz \
  && USER=root ./install.sh --silent /tmp/intel.cfg \
  && cd \
- && rm -r /tmp/intel
+ && rm -rf /tmp/intel*
 
 ENV CC=/opt/intel/bin/icc CXX=/opt/intel/bin/icpc PATH="/opt/intel/bin:${PATH}" LD_LIBRARY_PATH="/opt/intel/lib/intel64:${LD_LIBRARY_PATH}"
 

--- a/docker/intel/Dockerfile-15
+++ b/docker/intel/Dockerfile-15
@@ -34,9 +34,9 @@ RUN cd /tmp \
  && curl -sL http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/4933/l_compxe_2015.1.133.tgz | tar --strip-components=1 -xz \
  && USER=root ./install.sh --silent /tmp/intel.cfg \
  && cd \
- && rm -r /tmp/intel
-
-RUN /opt/intel/ism/uninstall.sh --silent
+ && rm -r /tmp/intel \
+ && /opt/intel/ism/uninstall.sh --silent \
+ && rm -f /tmp/intelremotemonfifo.*
 
 ENV CC=/opt/intel/bin/icc CXX=/opt/intel/bin/icpc PATH="/opt/intel/bin:${PATH}" LD_LIBRARY_PATH="/opt/intel/lib/intel64:${LD_LIBRARY_PATH}"
 

--- a/docker/intel/Dockerfile-15
+++ b/docker/intel/Dockerfile-15
@@ -34,7 +34,9 @@ RUN cd /tmp \
  && curl -sL http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/4933/l_compxe_2015.1.133.tgz | tar --strip-components=1 -xz \
  && USER=root ./install.sh --silent /tmp/intel.cfg \
  && cd \
- && rm -rf /tmp/intel*
+ && rm -r /tmp/intel
+
+RUN /opt/intel/ism/uninstall.sh --silent
 
 ENV CC=/opt/intel/bin/icc CXX=/opt/intel/bin/icpc PATH="/opt/intel/bin:${PATH}" LD_LIBRARY_PATH="/opt/intel/lib/intel64:${LD_LIBRARY_PATH}"
 

--- a/docker/intel/Dockerfile-15
+++ b/docker/intel/Dockerfile-15
@@ -24,7 +24,8 @@ RUN apt-get update && apt-get install -y \
 
 # CMake
 RUN cd /usr/local \
-&& curl -sL https://cmake.org/files/v3.10/cmake-3.10.3-Linux-x86_64.tar.gz | tar --strip-components=1 -xz
+&& curl -sL https://cmake.org/files/v3.10/cmake-3.10.3-Linux-x86_64.tar.gz | tar --strip-components=1 -xz \
+&& rm -r /usr/local/man
 
 # Intel Compiler
 COPY intel-15.cfg /tmp/intel.cfg

--- a/docker/intel/Dockerfile-18
+++ b/docker/intel/Dockerfile-18
@@ -35,6 +35,8 @@ RUN cd /tmp \
  && cd \
  && rm -r /tmp/intel
 
+RUN /opt/intel/ism/uninstall.sh --silent
+
 ENV CC=/opt/intel/bin/icc CXX=/opt/intel/bin/icpc PATH="/opt/intel/bin:${PATH}" LD_LIBRARY_PATH="/opt/intel/lib/intel64:${LD_LIBRARY_PATH}"
 ENV PATH="/opt/intel/compilers_and_libraries_2018.5.274/linux/mpi/intel64/bin:${PATH}" I_MPI_ROOT=/opt/intel/compilers_and_libraries_2018.5.274/linux/mpi
 RUN ln -s /opt/intel/compilers_and_libraries_2018.5.274/linux/mpi/intel64/bin/mpicxx /opt/intel/compilers_and_libraries_2018.5.274/linux/mpi/intel64/bin/mpic++

--- a/docker/intel/Dockerfile-18
+++ b/docker/intel/Dockerfile-18
@@ -33,9 +33,9 @@ RUN cd /tmp \
  && curl -sL http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13717/parallel_studio_xe_2018_update4_cluster_edition_online.tgz | tar --strip-components=1 -xz \
  && USER=root ./install.sh --silent /tmp/intel.cfg \
  && cd \
- && rm -r /tmp/intel
-
-RUN /opt/intel/ism/uninstall.sh --silent
+ && rm -r /tmp/intel \
+ && /opt/intel/ism/uninstall.sh --silent \
+ && rm -f /tmp/intelremotemonfifo.*
 
 ENV CC=/opt/intel/bin/icc CXX=/opt/intel/bin/icpc PATH="/opt/intel/bin:${PATH}" LD_LIBRARY_PATH="/opt/intel/lib/intel64:${LD_LIBRARY_PATH}"
 ENV PATH="/opt/intel/compilers_and_libraries_2018.5.274/linux/mpi/intel64/bin:${PATH}" I_MPI_ROOT=/opt/intel/compilers_and_libraries_2018.5.274/linux/mpi

--- a/docker/intel/Dockerfile-18
+++ b/docker/intel/Dockerfile-18
@@ -23,7 +23,8 @@ RUN apt-get update && apt-get install -y \
 
 # CMake
 RUN cd /usr/local \
-&& curl -sL https://cmake.org/files/v3.11/cmake-3.11.0-Linux-x86_64.tar.gz | tar --strip-components=1 -xz
+&& curl -sL https://cmake.org/files/v3.11/cmake-3.11.0-Linux-x86_64.tar.gz | tar --strip-components=1 -xz \
+&& rm -r /usr/local/man
 
 # Intel Compiler
 COPY intel.cfg /tmp/

--- a/docker/opensuse/Dockerfile-15.0
+++ b/docker/opensuse/Dockerfile-15.0
@@ -1,5 +1,6 @@
 FROM opensuse/leap:15.0
 MAINTAINER Florian Weik <fweik@icp.uni-stuttgart.de>
+RUN ln -s /usr/sbin/update-alternatives /usr/bin
 RUN zypper -n --gpg-auto-import-keys refresh \
 && zypper -n --gpg-auto-import-keys install \
   gcc-c++ \
@@ -18,6 +19,6 @@ RUN zypper -n --gpg-auto-import-keys refresh \
   ccache \
   curl \
   && update-alternatives --install /usr/bin/pycodestyle pycodestyle /usr/bin/pycodestyle-2.7 1
-RUN useradd -m espresso
+RUN /usr/sbin/useradd -m espresso
 USER 1000
 WORKDIR /home/espresso

--- a/docker/ubuntu-python3/Dockerfile-18.04
+++ b/docker/ubuntu-python3/Dockerfile-18.04
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 MAINTAINER Florian Weik <fweik@icp.uni-stuttgart.de>
 ENV DEBIAN_FRONTEND noninteractive
-COPY build-and-install-scafacos.sh /tmp
+COPY build-and-install-scafacos.sh /tmp/
 RUN apt-get update && apt-get install -y \
     apt-utils \
     cmake \

--- a/docker/ubuntu/Dockerfile-16.04
+++ b/docker/ubuntu/Dockerfile-16.04
@@ -1,7 +1,7 @@
 FROM ubuntu:xenial
 MAINTAINER Florian Weik <fweik@icp.uni-stuttgart.de>
 ENV DEBIAN_FRONTEND noninteractive
-COPY build-and-install-scafacos.sh /tmp
+COPY build-and-install-scafacos.sh /tmp/
 RUN apt-get update && apt-get install -y \
     apt-utils \
     cmake \

--- a/docker/ubuntu/Dockerfile-18.04
+++ b/docker/ubuntu/Dockerfile-18.04
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 MAINTAINER Florian Weik <fweik@icp.uni-stuttgart.de>
 ENV DEBIAN_FRONTEND noninteractive
-COPY build-and-install-scafacos.sh /tmp
+COPY build-and-install-scafacos.sh /tmp/
 RUN apt-get update && apt-get install --no-install-recommends -y \
     apt-utils \
     cmake \

--- a/docker/ubuntu/generate.sh
+++ b/docker/ubuntu/generate.sh
@@ -1,4 +1,4 @@
-#!/busybox/sh
+#!/bin/sh
 
 set -e
 

--- a/docker/ubuntu/generate.sh
+++ b/docker/ubuntu/generate.sh
@@ -1,11 +1,11 @@
-#!/bin/sh
+#!/busybox/sh
 
 set -e
 
 base=$(ls Dockerfile-[0-9\.]* | tail -n 1)
 img=$(grep FROM $base | awk '{print $2}')
 
-qemu_ver=$(wget -qO - "https://api.github.com/repos/multiarch/qemu-user-static/releases/latest" | grep '"tag_name":' |sed -E 's/.*"([^"]+)".*/\1/')
+qemu_ver=$(wget -qO - "https://api.github.com/repos/multiarch/qemu-user-static/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
 
 for os_arch in $*; do
 

--- a/maintainer/docker_build.sh
+++ b/maintainer/docker_build.sh
@@ -14,6 +14,6 @@ function cmd {
 cmd "cd docker/${CI_JOB_NAME%:*}"
 echo "ACTIVATION_LICENSE_FILE=$INTEL_LICENSE_SERVER" >> intel.cfg
 echo "ACTIVATION_LICENSE_FILE=$INTEL_LICENSE_SERVER" >> intel-15.cfg
-test -f Dockerfile-${CI_JOB_NAME#*:} || cmd "./generate.sh ${CI_JOB_NAME#*:}"
+test -f Dockerfile-${CI_JOB_NAME#*:} || cmd "sh generate.sh ${CI_JOB_NAME#*:}"
 cmd "/kaniko/executor --context $PWD --dockerfile Dockerfile-${CI_JOB_NAME#*:}* --destination $CI_REGISTRY/$CI_PROJECT_PATH/test/$CI_JOB_NAME-$CI_COMMIT_SHA --cache=true --cache-repo $CI_REGISTRY/$CI_PROJECT_PATH/cache"
 test "$CI_COMMIT_REF_NAME" != "master" || cmd "/kaniko/executor --context $PWD --dockerfile Dockerfile-${CI_JOB_NAME#*:}* --destination $CI_REGISTRY/$CI_PROJECT_PATH/$CI_JOB_NAME --cache=true --cache-repo $CI_REGISTRY/$CI_PROJECT_PATH/cache"

--- a/maintainer/docker_build.sh
+++ b/maintainer/docker_build.sh
@@ -15,8 +15,5 @@ cmd "cd docker/${CI_JOB_NAME%:*}"
 echo "ACTIVATION_LICENSE_FILE=$INTEL_LICENSE_SERVER" >> intel.cfg
 echo "ACTIVATION_LICENSE_FILE=$INTEL_LICENSE_SERVER" >> intel-15.cfg
 test -f Dockerfile-${CI_JOB_NAME#*:} || cmd "./generate.sh ${CI_JOB_NAME#*:}"
-cmd "docker build -f Dockerfile-${CI_JOB_NAME#*:}* --pull -t $CI_REGISTRY/$CI_PROJECT_PATH/test/$CI_JOB_NAME-$CI_COMMIT_SHA --cache-from $CI_REGISTRY/$CI_PROJECT_PATH/$CI_JOB_NAME ."
-cmd "docker push $CI_REGISTRY/$CI_PROJECT_PATH/test/$CI_JOB_NAME-$CI_COMMIT_SHA"
-test "$CI_COMMIT_REF_NAME" != "master" || cmd "docker tag $CI_REGISTRY/$CI_PROJECT_PATH/test/$CI_JOB_NAME-$CI_COMMIT_SHA $CI_REGISTRY/$CI_PROJECT_PATH/$CI_JOB_NAME"
-test "$CI_COMMIT_REF_NAME" != "master" || cmd "docker push $CI_REGISTRY/$CI_PROJECT_PATH/$CI_JOB_NAME"
-
+cmd "/kaniko/executor --context $PWD --dockerfile Dockerfile-${CI_JOB_NAME#*:}* --destination $CI_REGISTRY/$CI_PROJECT_PATH/test/$CI_JOB_NAME-$CI_COMMIT_SHA --cache=true --cache-repo $CI_REGISTRY/$CI_PROJECT_PATH/cache"
+test "$CI_COMMIT_REF_NAME" != "master" || cmd "/kaniko/executor --context $PWD --dockerfile Dockerfile-${CI_JOB_NAME#*:}* --destination $CI_REGISTRY/$CI_PROJECT_PATH/$CI_JOB_NAME --cache=true --cache-repo $CI_REGISTRY/$CI_PROJECT_PATH/cache"


### PR DESCRIPTION
Kaniko doesn't require a privileged container and is thus much more secure than `docker build`. Also, it does better caching and thus builds faster. It has been officially supported by GitLab for a few months already: https://docs.gitlab.com/ee/ci/docker/using_kaniko.html. Also, this change allows us to build in the cloud and not just on our GitLab server.