### PR TITLE
ubuntu18-python3: install jq.

### DIFF
--- a/docker/ubuntu-python3/Dockerfile-18.04
+++ b/docker/ubuntu-python3/Dockerfile-18.04
@@ -24,6 +24,7 @@ RUN apt-get update && apt-get install -y \
     vim \
     ccache \
     curl \
+    jq \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/*
 RUN bash /tmp/build-and-install-scafacos.sh


### PR DESCRIPTION
PR #78 introduced the new ubuntu container but omitted the installation of the jq package.

See [issue](https://github.com/espressomd/espresso/issues/2845)