### PR TITLE
CentOS/Fedora/OpenSUSE: migrate to Python3

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,13 +54,19 @@ stages:
 
 centos:7:
   <<: *build_definition
+centos-python3:7:
+  <<: *build_definition
 centos:next:
+  <<: *build_definition
+centos-python3:next:
   <<: *build_definition
 debian:9:
   <<: *build_definition
 opensuse:42.3:
   <<: *build_definition
 opensuse:15.0:
+  <<: *build_definition
+opensuse:15.1:
   <<: *build_definition
 ubuntu:16.04:
   <<: *build_definition
@@ -108,15 +114,21 @@ ubuntu:s390x:
   <<: *build_definition
 
 test/centos:7:
-  <<: *test_definition
+  <<: *test_v40_definition
+test/centos-python3:7:
+  <<: *test_py3_definition
 test/centos:next:
-  <<: *test_definition
+  <<: *test_v40_definition
+test/centos-python3:next:
+  <<: *test_py3_definition
 test/debian:9:
   <<: *test_definition
 test/opensuse:42.3:
   <<: *test_v40_definition
 test/opensuse:15.0:
-  <<: *test_definition
+  <<: *test_v40_definition
+test/opensuse:15.1:
+  <<: *test_py3_definition
 test/ubuntu:16.04:
   <<: *test_definition
 test/ubuntu:18.04:

--- a/docker/centos-python3/Dockerfile-7
+++ b/docker/centos-python3/Dockerfile-7
@@ -1,0 +1,31 @@
+FROM centos/devtoolset-6-toolchain-centos7
+USER root
+MAINTAINER Jean-Noel Grad <jgrad@icp.uni-stuttgart.de>
+RUN yum -y install epel-release && yum -y install \
+  make \
+  cmake3 \
+  openmpi-devel \
+  fftw-devel \
+  boost169-devel boost169-openmpi-devel \
+  git \
+  python36 \
+  python36-devel \
+  python36-pip \
+  python36-Cython \
+  python36-pycodestyle \
+  python36-pylint \
+  python36-numpy \
+  hdf5-openmpi-devel \
+  zlib-devel \
+  which \
+  vim \
+  ccache \
+  && yum clean all \
+  && ln -s /usr/bin/cmake3 /usr/bin/cmake \
+  && pip3 install h5py
+ENV BOOST_INCLUDEDIR=/usr/include/boost169
+ENV BOOST_LIBRARYDIR=/usr/lib64/boost169
+RUN ln -s /usr/lib64/openmpi/lib/boost169/libboost_mpi.so  /usr/lib64/boost169/libboost_mpi.so
+RUN useradd -m espresso -u 1000
+USER 1000
+WORKDIR /home/espresso

--- a/docker/centos-python3/Dockerfile-next
+++ b/docker/centos-python3/Dockerfile-next
@@ -1,0 +1,25 @@
+FROM fedora:latest
+MAINTAINER Jean-Noel Grad <jgrad@icp.uni-stuttgart.de>
+RUN yum -y install \
+  gcc gcc-c++ make \
+  cmake \
+  openmpi-devel \
+  fftw-devel \
+  boost-devel boost-openmpi-devel \
+  git \
+  python3 \
+  python3-devel \
+  python3-Cython \
+  python3-pycodestyle \
+  python3-pylint \
+  python3-numpy \
+  python3-h5py \
+  hdf5-openmpi-devel \
+  zlib-devel \
+  which \
+  vim \
+  ccache \
+  && yum clean all
+RUN useradd -m espresso
+USER 1000
+WORKDIR /home/espresso

--- a/docker/opensuse/Dockerfile-15.1
+++ b/docker/opensuse/Dockerfile-15.1
@@ -1,0 +1,28 @@
+FROM opensuse/leap:15.1
+MAINTAINER Jean-Noel Grad <jgrad@icp.uni-stuttgart.de>
+RUN ln -s /usr/sbin/update-alternatives /usr/bin
+RUN zypper -n --gpg-auto-import-keys refresh \
+&& zypper -n --gpg-auto-import-keys install \
+  gcc-c++ \
+  cmake \
+  Modules \
+  fftw3-devel \
+  libboost_serialization1_66_0-devel libboost_mpi1_66_0-devel  libboost_filesystem1_66_0-devel libboost_test1_66_0-devel \
+  python3 \
+  python3-Cython \
+  python3-setuptools \
+  python3-pycodestyle \
+  python3-pylint \
+  python3-numpy \
+  python3-numpy-devel \
+  python3-h5py \
+  git \
+  hdf5-openmpi-devel-static \
+  libhdf5-103-openmpi2 \
+  vim \
+  which \
+  ccache \
+  curl
+RUN /usr/sbin/useradd -m espresso
+USER 1000
+WORKDIR /home/espresso


### PR DESCRIPTION
Migrate CentOS/Fedora/OpenSUSE containers to Python3 (espressomd/espresso#2694). The Python3 container for OpenSUSE Leap uses version 15.1. Maintenance for version 15.0 ends next November.