### PR TITLE
Remove Sphinx where not needed

### DIFF
--- a/docker/clang/Dockerfile-6.0
+++ b/docker/clang/Dockerfile-6.0
@@ -22,7 +22,6 @@ RUN apt-get update && apt-get install -y \
     libhdf5-openmpi-dev \
     doxygen \
     vim \
-&& pip2 install --upgrade pip; pip2 install sphinx sphinxcontrib-bibtex --upgrade \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/* \
 && ln -s /usr/bin/llvm-symbolizer-6.0 /usr/bin/llvm-symbolizer \

--- a/docker/intel/Dockerfile-15
+++ b/docker/intel/Dockerfile-15
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y \
     doxygen \
     vim \
     ccache \
-&& pip2 install cython sphinx sphinxcontrib-bibtex numpydoc --upgrade \
+&& pip2 install cython --upgrade \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/* \
 && rm /usr/lib/pymodules/python2.7/vtk/vtkRenderingPython.so /usr/lib/pymodules/python2.7/vtk/vtkVolumeRenderingPython.so /usr/lib/pymodules/python2.7/vtk/vtkHybridPython.so /usr/lib/pymodules/python2.7/vtk/vtkWidgetsPython.so /usr/lib/pymodules/python2.7/vtk/vtkChartsPython.so /usr/lib/pymodules/python2.7/vtk/vtkGeovisPython.so /usr/lib/pymodules/python2.7/vtk/vtkInfovisPython.so /usr/lib/pymodules/python2.7/vtk/vtkViewsPython.so /usr/lib/pymodules/python2.7/vtk/vtkParallelPython.so


### PR DESCRIPTION
Sphinx is only used in the cuda container. Removing it from the other containers lowers the maintenance effort. This fixes the CI failure on master, caused by pip2 installing a Python3 version of Sphinx:
```
Successfully installed pip-19.1.1
Collecting sphinx
  Downloading https://files.pythonhosted.org/packages/89/1e/64c77163706556b647f99d67b42fced9d39ae6b1b86673965a2cd28037b5/Sphinx-2.1.2.tar.gz (6.3MB)
    Complete output from command python setup.py egg_info:
    ERROR: Sphinx requires at least Python 3.5 to run.
```
https://gitlab.icp.uni-stuttgart.de/espressomd/docker/-/jobs/127048
https://gitlab.icp.uni-stuttgart.de/espressomd/docker/-/jobs/127052