### PR TITLE
Reinstall python package `requests`

### DIFF
--- a/docker/clang/Dockerfile-6.0
+++ b/docker/clang/Dockerfile-6.0
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y \
     libhdf5-openmpi-dev \
     doxygen \
     vim \
+&& pip2 install requests \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/* \
 && ln -s /usr/bin/llvm-symbolizer-6.0 /usr/bin/llvm-symbolizer \


### PR DESCRIPTION
Removing Sphinx in #106 also removed its dependency `requests` in `clang:6.0`, but this container is used by the `style` job of the first stage, where `requests` is called to post messages via @espresso-ci. CI on espressomd/espresso is currently blocked because of this missing dependency:
https://gitlab.icp.uni-stuttgart.de/espressomd/espresso/-/jobs/127626