### PR TITLE
New image with CUDA 10.1 and pdflatex

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,6 +58,8 @@ cuda:tutorials:build:
   extends: .build_template
 cuda:9.0:build:
   extends: .build_template
+cuda:10.1:build:
+  extends: .build_template
 rocm-python3:latest:build:
   extends: .build_template
 intel-python3:18:build:
@@ -109,6 +111,8 @@ test/clang-python3:6.0:
 test/cuda:tutorials:
   extends: .test_template
 test/cuda:9.0:
+  extends: .test_template
+test/cuda:10.1:
   extends: .test_template
 test/rocm-python3:latest:
   extends: .test_template
@@ -166,6 +170,8 @@ clang-python3:6.0:
 cuda:tutorials:
   extends: .deploy_template
 cuda:9.0:
+  extends: .deploy_template
+cuda:10.1:
   extends: .deploy_template
 rocm-python3:latest:
   extends: .deploy_template

--- a/docker/cuda/Dockerfile-10.1
+++ b/docker/cuda/Dockerfile-10.1
@@ -41,7 +41,7 @@ RUN apt-get install -y --no-install-recommends software-properties-common \
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m espresso && usermod -a -G www-data espresso
-USER 1000
+USER espresso
 
 # install extra LaTeX packages locally
 RUN tlmgr init-usertree \

--- a/docker/cuda/Dockerfile-10.1
+++ b/docker/cuda/Dockerfile-10.1
@@ -1,0 +1,51 @@
+FROM nvidia/cuda:10.1-devel-ubuntu18.04
+MAINTAINER Jean-Noel Grad <jgrad@icp.uni-stuttgart.de>
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && apt-get install -y \
+    apt-utils \
+    cmake \
+    build-essential \
+    pkg-config \
+    openmpi-bin libopenmpi-dev \
+    libfftw3-dev \
+    libboost-dev libboost-serialization-dev libboost-mpi-dev libboost-filesystem-dev libboost-test-dev \
+    libgsl-dev \
+    cython3 python3 python3-numpy python3-h5py \
+    python3-dev python3-pip \
+    lcov \
+    git \
+    pycodestyle pylint3 \
+    python3-vtk7 \
+    libhdf5-openmpi-dev \
+    libhdf5-openmpi-100:amd64 \
+    libhdf5-100:amd64 \
+    doxygen \
+    vim \
+    ccache \
+    graphviz \
+    curl \
+    jq
+
+# install Python3 packages required for tutorials
+RUN python3 -m pip install --upgrade pip \
+    && pip3 install --upgrade setuptools \
+    && pip3 install --upgrade six scipy matplotlib jupyter ipython nbconvert 'sphinx!=2.1.0' sphinxcontrib-bibtex numpydoc
+
+# install TeXlive 2019 from a PPA
+RUN apt-get install -y --no-install-recommends software-properties-common \
+    && add-apt-repository -y ppa:jonathonf/texlive \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends texlive-latex-recommended texlive-fonts-recommended
+
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m espresso && usermod -a -G www-data espresso
+USER 1000
+
+# install extra LaTeX packages locally
+RUN tlmgr init-usertree \
+    && tlmgr install pgf tikz-3dplot revtex units mhchem chemgreek todonotes upquote framed subfigure cleveref \
+    && tlmgr install lm stmaryrd 2>&1 || : \
+    && updmap -user
+
+WORKDIR /home/espresso

--- a/docker/cuda/Dockerfile-10.1
+++ b/docker/cuda/Dockerfile-10.1
@@ -25,7 +25,8 @@ RUN apt-get update && apt-get install -y \
     graphviz \
     curl \
     wget \
-    jq
+    jq \
+    ffmpeg
 
 # install Python3 packages required for tutorials
 RUN python3 -m pip install --upgrade pip \

--- a/docker/cuda/Dockerfile-10.1
+++ b/docker/cuda/Dockerfile-10.1
@@ -24,6 +24,7 @@ RUN apt-get update && apt-get install -y \
     ccache \
     graphviz \
     curl \
+    wget \
     jq
 
 # install Python3 packages required for tutorials


### PR DESCRIPTION
Required for espressomd/espresso#1487.
Adds pdflatex, jupyter, and tutorials-specific python packages.
Enables CUDA 10 testing (formerly achieved by `intel-python3:18`).