### PR TITLE
Fix issues with tutorials deployment

### DIFF
--- a/docker/cuda/Dockerfile-10.1
+++ b/docker/cuda/Dockerfile-10.1
@@ -26,7 +26,8 @@ RUN apt-get update && apt-get install -y \
     curl \
     wget \
     jq \
-    ffmpeg
+    ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
 
 # install Python3 packages required for tutorials
 RUN python3 -m pip install --upgrade pip \
@@ -34,12 +35,11 @@ RUN python3 -m pip install --upgrade pip \
     && pip3 install --upgrade six scipy matplotlib jupyter ipython nbconvert lxml 'sphinx!=2.1.0' sphinxcontrib-bibtex numpydoc
 
 # install TeXlive 2019 from a PPA
-RUN apt-get install -y --no-install-recommends software-properties-common \
+RUN apt-get update && apt-get install -y --no-install-recommends software-properties-common \
     && add-apt-repository -y ppa:jonathonf/texlive \
     && apt-get update \
-    && apt-get install -y --no-install-recommends texlive-latex-recommended texlive-fonts-recommended
-
-RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y --no-install-recommends texlive-latex-recommended texlive-fonts-recommended \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m espresso && usermod -a -G www-data espresso
 USER espresso

--- a/docker/cuda/Dockerfile-10.1
+++ b/docker/cuda/Dockerfile-10.1
@@ -46,7 +46,8 @@ USER espresso
 
 # install extra LaTeX packages locally
 RUN tlmgr init-usertree \
-    && tlmgr install pgf tikz-3dplot revtex units mhchem chemgreek todonotes upquote framed subfigure cleveref \
+    && tlmgr install pgf tikz-3dplot revtex units mhchem chemgreek todonotes upquote framed subfigure cleveref 2>&1 | tee $HOME/tlmgr.log \
+    && if [ "$(grep 'TLPDB::from_file could not download' $HOME/tlmgr.log)" != "" ]; then exit 1; else rm $HOME/tlmgr.log; fi \
     && tlmgr install lm stmaryrd 2>&1 || : \
     && updmap -user
 

--- a/docker/cuda/Dockerfile-9.0
+++ b/docker/cuda/Dockerfile-9.0
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y \
     vim \
     ccache \
     graphviz \
-&& pip3 install --upgrade sphinxcontrib-bibtex 'sphinx!=2.1.0' \
+&& pip3 install --upgrade lxml sphinxcontrib-bibtex 'sphinx!=2.1.0' \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Fixes espressomd/espresso#3038, fixes espressomd/espresso#3035,
fixes espressomd/espresso#3041, fixes espressomd/espresso#3042
Partial fix for #126: fail a build when LaTeX packages cannot be downloaded