### PR TITLE
Update containers for 4.1 release

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,6 +48,8 @@ centos-python3:next:build:
   extends: .build_template
 debian-python3:9:build:
   extends: .build_template
+debian-python3:10:build:
+  extends: .build_template
 opensuse:15.1:build:
   extends: .build_template
 ubuntu-python3:wo-dependencies:build:
@@ -103,6 +105,8 @@ test/centos-python3:7:
 test/centos-python3:next:
   extends: .test_template
 test/debian-python3:9:
+  extends: .test_template
+test/debian-python3:10:
   extends: .test_template
 test/opensuse:15.1:
   extends: .test_template
@@ -162,6 +166,8 @@ centos-python3:7:
 centos-python3:next:
   extends: .deploy_template
 debian-python3:9:
+  extends: .deploy_template
+debian-python3:10:
   extends: .deploy_template
 opensuse:15.1:
   extends: .deploy_template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,8 +52,6 @@ debian-python3:10:build:
   extends: .build_template
 opensuse:15.1:build:
   extends: .build_template
-ubuntu-python3:wo-dependencies:build:
-  extends: .build_template
 clang-python3:6.0:build:
   extends: .build_template
 cuda:tutorials:build:
@@ -102,6 +100,7 @@ ubuntu:s390x:build:
     - .build_template
     - .manual_template
 
+
 test/centos-python3:7:
   extends: .test_template
 test/centos-python3:next:
@@ -137,6 +136,8 @@ test/intel-python3:18:
     - icp
 test/ubuntu-python3:18.04:
   extends: .test_template
+test/ubuntu-python3:wo-dependencies:
+  extends: .test_template
 test/ubuntu-python3:min_boost:
   extends: .test_template
 test/ubuntu-python3:cuda-10.1:
@@ -161,8 +162,6 @@ test/ubuntu:s390x:
   extends:
     - .test_template
     - .manual_template
-test/ubuntu-python3:wo-dependencies:
-  extends: .test_template
 
 
 centos-python3:7:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,6 +79,8 @@ ubuntu-python3:wo-dependencies:build:
   extends: .build_template
 ubuntu-python3:min_boost:build:
   extends: .build_template
+ubuntu-python3:cuda-10.1:build:
+  extends: .build_template
 ubuntu:arm64:build:
   extends:
     - .build_template
@@ -136,6 +138,8 @@ test/intel-python3:18:
 test/ubuntu-python3:18.04:
   extends: .test_template
 test/ubuntu-python3:min_boost:
+  extends: .test_template
+test/ubuntu-python3:cuda-10.1:
   extends: .test_template
 test/ubuntu:arm64:
   extends:
@@ -195,6 +199,8 @@ ubuntu-python3:18.04:
 ubuntu-python3:wo-dependencies:
   extends: .deploy_template
 ubuntu-python3:min_boost:
+  extends: .deploy_template
+ubuntu-python3:cuda-10.1:
   extends: .deploy_template
 ubuntu:arm64:
   extends:

--- a/docker/clang-python3/Dockerfile-6.0
+++ b/docker/clang-python3/Dockerfile-6.0
@@ -10,14 +10,14 @@ RUN apt-get update && apt-get install -y \
     libboost-dev libboost-serialization-dev libboost-mpi-dev libboost-filesystem-dev libboost-test-dev \
     cython3 python3 python3-numpy python3-h5py \
     git \
-    pep8 pylint3 \
+    python3-pep8 pylint3 \
 #   python3-vtk7 \ # not available in 16.04
     python3-pip \
     libpython3-dev \
     libhdf5-openmpi-dev \
     doxygen \
     vim \
-&& pip3 install requests autopep8==0.9.1 \
+&& pip3 install requests autopep8==1.3.4 pycodestyle==2.3.1 \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/* \
 && ln -s /usr/bin/llvm-symbolizer-6.0 /usr/bin/llvm-symbolizer \

--- a/docker/debian-python3/Dockerfile-10
+++ b/docker/debian-python3/Dockerfile-10
@@ -1,0 +1,25 @@
+FROM debian:buster
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && apt-get install -y \
+    apt-utils \
+    cmake \
+    build-essential \
+    clang \
+    openmpi-bin \
+    libfftw3-dev \
+    libboost-dev libboost-serialization-dev libboost-mpi-dev libboost-filesystem-dev libboost-test-dev \
+    cython3 python3 python3-numpy python3-h5py python3-vtk7 \
+    lcov \
+    git \
+    pycodestyle pylint3 \
+    python3-pip \
+    libpython3-dev \
+    libhdf5-openmpi-dev \
+    vim \
+    ccache \
+&& apt-get clean \
+&& rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m espresso
+USER 1000
+WORKDIR /home/espresso

--- a/docker/ubuntu-python3/Dockerfile-cuda-10.1
+++ b/docker/ubuntu-python3/Dockerfile-cuda-10.1
@@ -1,0 +1,64 @@
+FROM nvidia/cuda:10.1-devel-ubuntu18.04
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && apt-get install -y \
+    apt-utils \
+    build-essential \
+    cmake ccache \
+    gfortran \
+    pkg-config \
+    autoconf \
+    openmpi-bin libopenmpi-dev \
+    libfftw3-dev \
+    libboost-dev libboost-serialization-dev libboost-mpi-dev libboost-filesystem-dev libboost-test-dev \
+    libgsl-dev \
+    cython3 python3 python3-numpy python3-h5py python3-vtk7 \
+    python3-dev python3-pip \
+    pycodestyle pylint3 \
+    libhdf5-openmpi-dev \
+    libhdf5-openmpi-100:amd64 \
+    libhdf5-100:amd64 \
+    curl wget \
+    lcov \
+    git \
+    doxygen \
+    vim \
+    graphviz jq ffmpeg \
+&& apt-get install -y --no-install-recommends software-properties-common \
+&& apt-get clean \
+&& rm -rf /var/lib/apt/lists/*
+
+# install Python3 packages required for tutorials and documentation
+RUN python3 -m pip install --upgrade pip \
+&& pip3 install --upgrade setuptools \
+&& pip3 install --upgrade six scipy matplotlib jupyter ipython nbconvert lxml 'sphinx!=2.1.0' sphinxcontrib-bibtex numpydoc
+
+# install ScaFaCoS
+COPY build-and-install-scafacos.sh /tmp/
+RUN bash /tmp/build-and-install-scafacos.sh \
+&& rm /tmp/build-and-install-scafacos.sh
+
+# install TeXlive 2019 from a PPA
+RUN add-apt-repository -y ppa:jonathonf/texlive \
+&& apt-get update \
+&& apt-get install -y --no-install-recommends texlive-latex-recommended texlive-fonts-recommended \
+&& apt-get clean \
+&& rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m espresso && usermod -a -G www-data espresso
+USER espresso
+
+# install extra LaTeX packages locally
+RUN tlmgr init-usertree \
+&& tlmgr option repository http://ftp.fau.de/ctan/systems/texlive/tlnet \
+&& tlmgr install pgf tikz-3dplot revtex units mhchem chemgreek todonotes upquote framed subfigure cleveref 2>&1 | tee $HOME/tlmgr.log \
+&& if [ "$(grep 'TLPDB::from_file could not download' $HOME/tlmgr.log)" != "" ]; then exit 1; else rm $HOME/tlmgr.log; fi \
+&& tlmgr install lm stmaryrd 2>&1 || : \
+&& updmap -user
+
+# download waLBerla
+RUN cd /home/espresso \
+&& git clone https://gitlab.icp.uni-stuttgart.de/espressomd/walberla_for_es.git walberla \
+&& cd walberla \
+&& cmake .
+
+WORKDIR /home/espresso


### PR DESCRIPTION
* Install autopep8 from Ubuntu 18 in the Ubuntu 16 Clang image (espressomd/espresso#2306)
* Create Debian 10 to replace Debian 9 (end of support next year)
* Create a CUDA 10.1 image with all dependencies to simplify documentation CI/CD