### PR TITLE
don't rebuild image in deploy stage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,6 +30,9 @@ stages:
   timeout: 15m
   script:
   - echo "FROM $CI_REGISTRY/$CI_PROJECT_PATH/test/$CI_JOB_NAME-$CI_COMMIT_SHA" | /kaniko/executor --dockerfile /dev/stdin --destination $CI_REGISTRY/$CI_PROJECT_PATH/$CI_JOB_NAME
+  tags:
+    - docker
+    - linux
   only:
     - master
     - /[0-9]\..*/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,6 +27,9 @@ stages:
 .deploy_template:
   extends: .build_template
   stage: deploy
+  timeout: 15m
+  script:
+  - echo "FROM $CI_REGISTRY/$CI_PROJECT_PATH/test/$CI_JOB_NAME-$CI_COMMIT_SHA" | /kaniko/executor --dockerfile /dev/stdin --destination $CI_REGISTRY/$CI_PROJECT_PATH/$CI_JOB_NAME
   only:
     - master
     - /[0-9]\..*/


### PR DESCRIPTION
@jngrad

Manually tested with
```
docker run \
  --env CI_REGISTRY=gitlab.icp.uni-stuttgart.de:4567 \
  --env CI_PROJECT_PATH=espressomd/docker \
  --env CI_JOB_NAME=debian-python3:10 \
  --env CI_COMMIT_SHA=81272ae9f01c0424ac3af9b283c4b24dc0800c0e  \
  -it --entrypoint "" gcr.io/kaniko-project/executor:debug  /busybox/sh
echo "FROM $CI_REGISTRY/$CI_PROJECT_PATH/test/$CI_JOB_NAME-$CI_COMMIT_SHA" | \
  /kaniko/executor --dockerfile /dev/stdin \
  --destination $CI_REGISTRY/$CI_PROJECT_PATH/$CI_JOB_NAME
```