### PR TITLE
Increase timeouts and silence boost build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,7 @@ stages:
     - echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_REGISTRY_USER\",\"password\":\"$CI_REGISTRY_PASSWORD\"}}}" > /kaniko/.docker/config.json
   script:
     - sh maintainer/docker_build.sh
-  timeout: 1h
+  timeout: 2h
   interruptible: true
   tags:
     - docker
@@ -79,7 +79,6 @@ ubuntu-python3:cuda-9.0:build:
   extends: .build_template
 ubuntu-python3:cuda-10.1:build:
   extends: .build_template
-  timeout: 2h
 ubuntu:arm64:build:
   extends:
     - .build_template

--- a/docker/intel-python3/Dockerfile-18
+++ b/docker/intel-python3/Dockerfile-18
@@ -48,7 +48,7 @@ RUN cd /tmp \
  && cd boost_1_66_0 \
  && echo 'using mpi : mpiicpc ;' > tools/build/src/user-config.jam \
  && ./bootstrap.sh \
- && ./b2 -j $(nproc) -d0 toolset=intel install --prefix=/opt/boost \
+ && ./b2 -j $(nproc) -d0 warnings=off toolset=intel install --prefix=/opt/boost \
  && cd \
  && rm -r /tmp/boost
 

--- a/docker/ubuntu-python3/Dockerfile-min_boost
+++ b/docker/ubuntu-python3/Dockerfile-min_boost
@@ -33,7 +33,7 @@ RUN cd /tmp \
     && cd boost_1_55_0 \
     && ./bootstrap.sh \
     && echo "using mpi ;" >> project-config.jam \
-    && ./b2 -j $(nproc) install --prefix=/opt/boost \
+    && ./b2 -j $(nproc) -d0 warnings=off install --prefix=/opt/boost \
     && cd \
     && rm -r /tmp/boost
 


### PR DESCRIPTION
Boost was spamming the logs so we can't see why builds failed (https://gitlab.icp.uni-stuttgart.de/espressomd/docker/-/jobs/166524). And some jobs run into the timeout (https://gitlab.icp.uni-stuttgart.de/espressomd/docker/-/jobs/166527, https://gitlab.icp.uni-stuttgart.de/espressomd/docker/-/jobs/166529). @jngrad