### PR TITLE
rocFFT from ROCm 2.9.0 is broken

### DIFF
--- a/docker/rocm-python3/Dockerfile-latest
+++ b/docker/rocm-python3/Dockerfile-latest
@@ -25,6 +25,13 @@ RUN apt-get update && apt-get install -y \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/*
 
+# patch rocFFT as a workaround for https://github.com/espressomd/espresso/issues/3235
+RUN dpkg-query --show --showformat '${Version}' rocfft | grep -qv '0\.9\.7\.722' || ( \
+    git clone -b rocm-2.9 https://github.com/ROCmSoftwarePlatform/rocFFT.git && \
+    cd rocFFT && git diff 3b0813f~1..3b0813f library/src/plan.cpp | git apply && mkdir build && cd build && \
+    cmake .. -DCMAKE_INSTALL_PREFIX=/opt/rocm -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hcc -DCMAKE_CXX_FLAGS=--amdgpu-target=gfx900 && make -j$(nproc) install && \
+    cd && rm -rf rocFFT )
+
 RUN useradd -m espresso
 USER 1000
 WORKDIR /home/espresso


### PR DESCRIPTION
Fixes https://github.com/espressomd/espresso/issues/3235

Bug introduced by https://github.com/ROCmSoftwarePlatform/rocFFT/commit/0453c45243080d1f34ed112573bd15e1a4e8471c (https://github.com/ROCmSoftwarePlatform/rocFFT/pull/248), which is part of ROCm 2.9.
Bug fixed by https://github.com/ROCmSoftwarePlatform/rocFFT/commit/3b0813fe17a8ba39ff9b25b3c1c6f651691e95bf (https://github.com/ROCmSoftwarePlatform/rocFFT/pull/266), which is on the current development branch.

It's this change:
https://github.com/ROCmSoftwarePlatform/rocFFT/pull/266/files#diff-1565af64fc2dada53e6d01ad85ead0f1L829-R829