### PR TITLE
Add python module "requests"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -163,6 +163,12 @@ test/ubuntu-python3:cuda-9.0:
 test/ubuntu-python3:cuda-10.1:
   extends: .test_template
   needs: ["ubuntu-python3:cuda-10.1:build"]
+  script:
+    - git clone --depth=1 --recursive https://github.com/espressomd/espresso
+    - cd espresso
+    - maintainer/CI/build_cmake.sh
+    - cd build
+    - make sphinx
 test/ubuntu:arm64:
   extends:
     - .test_template

--- a/docker/ubuntu-python3/Dockerfile-cuda-10.1
+++ b/docker/ubuntu-python3/Dockerfile-cuda-10.1
@@ -54,5 +54,6 @@ RUN tlmgr init-usertree \
 
 # install Python3 packages locally
 RUN pip3 install --user --upgrade 'sphinx>=2.0,!=2.1.0' sphinxcontrib-bibtex 'MDAnalysis==0.16' 'pint>=0.9'
+ENV PATH="/home/espresso/.local/bin:${PATH}"
 
 WORKDIR /home/espresso

--- a/docker/ubuntu-python3/Dockerfile-cuda-9.0
+++ b/docker/ubuntu-python3/Dockerfile-cuda-9.0
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y \
     libgsl-dev \
     cython3 python3 python3-numpy python3-h5py \
     git \
+    python3-pip \
 #   python3-vtk7 \ # not available in 16.04
     libpython-dev \
     libhdf5-openmpi-dev \
@@ -22,6 +23,7 @@ RUN apt-get update && apt-get install -y \
     vim \
     ccache \
     graphviz \
+&& pip3 install requests \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Fix silent regressions from #144:
- `cuda:9` needs `requests` for the `style_doxygen` job
- `cuda:10.1` needs to set the `$PATH` for sphinx to work (now tested)