### PR TITLE
Add python module "lxml"

### DIFF
--- a/docker/ubuntu-python3/Dockerfile-cuda-9.0
+++ b/docker/ubuntu-python3/Dockerfile-cuda-9.0
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y \
     git \
     python3-pip \
 #   python3-vtk7 \ # not available in 16.04
+    python3-lxml \
     libpython-dev \
     libhdf5-openmpi-dev \
     libhdf5-openmpi-10:amd64 \

--- a/docker/ubuntu-python3/Dockerfile-cuda-9.0
+++ b/docker/ubuntu-python3/Dockerfile-cuda-9.0
@@ -13,9 +13,9 @@ RUN apt-get update && apt-get install -y \
     libgsl-dev \
     cython3 python3 python3-numpy python3-h5py \
     git \
-    python3-pip \
 #   python3-vtk7 \ # not available in 16.04
     python3-lxml \
+    python3-requests \
     libpython-dev \
     libhdf5-openmpi-dev \
     libhdf5-openmpi-10:amd64 \
@@ -24,7 +24,6 @@ RUN apt-get update && apt-get install -y \
     vim \
     ccache \
     graphviz \
-&& pip3 install requests \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Fixes espressomd/espresso#3298: silent regression from #144. Image `cuda:9` needs `lxml` for the weekly `deploy_tutorials` job. I'll update `requirements.txt` on espressomd/espresso to list **all** python dependencies and help prevent these silent regressions (after espressomd/espresso#3293 is merged).