### PR TITLE
Upgrade CMake and Cython in Ubuntu 16.04 images

### DIFF
--- a/docker/clang-python3/Dockerfile-6.0
+++ b/docker/clang-python3/Dockerfile-6.0
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
     openmpi-bin \
     libfftw3-dev \
     libboost-dev libboost-serialization-dev libboost-mpi-dev libboost-filesystem-dev libboost-test-dev \
-    cython3 python3 python3-numpy python3-h5py \
+    python3 python3-numpy python3-h5py \
     git \
 #   python3-vtk7 \ # not available in 16.04
     python3-pip \
@@ -31,11 +31,6 @@ RUN cd /tmp \
  && cd \
  && rm -r /tmp/ccache-3.4.3
 
-# more recent version of CMake required for Clang-tidy
-RUN cd /usr/local \
-&& curl -sL https://cmake.org/files/v3.8/cmake-3.8.2-Linux-x86_64.tar.gz | tar --strip-components=1 -xz \
-&& rm -r /usr/local/man
-
 RUN cd /usr/src && \
     git clone --depth=1 -b 1.9.5 https://github.com/thrust/thrust.git && \
     rm -r /usr/local/cuda/include/thrust && \
@@ -51,6 +46,6 @@ RUN useradd -m espresso && usermod -a -G www-data espresso
 USER espresso
 ENV HOME="/home/espresso"
 # install Python3 packages locally
-RUN pip3 install --user requests autopep8==1.3.4 pycodestyle==2.3.1 pylint==2.2.2 astroid==2.1.0 isort==4.3.4
+RUN pip3 install --user requests autopep8==1.3.4 pycodestyle==2.3.1 pylint==2.2.2 astroid==2.1.0 isort==4.3.4 cython==0.26 cmake==3.10.3
 ENV PATH="${PATH}:${HOME}/.local/bin"
 WORKDIR /home/espresso

--- a/docker/ubuntu-python3/Dockerfile-cuda-9.0
+++ b/docker/ubuntu-python3/Dockerfile-cuda-9.0
@@ -2,7 +2,6 @@ FROM nvidia/cuda:9.0-devel-ubuntu16.04
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y \
     apt-utils \
-    cmake \
     build-essential \
     curl \
     lcov \
@@ -11,7 +10,7 @@ RUN apt-get update && apt-get install -y \
     libfftw3-dev \
     libboost-dev libboost-serialization-dev libboost-mpi-dev libboost-filesystem-dev libboost-test-dev \
     libgsl-dev \
-    cython3 python3 python3-numpy python3-h5py \
+    python3 python3-numpy python3-h5py python3-pip \
     git \
 #   python3-vtk7 \ # not available in 16.04
     python3-lxml \
@@ -28,5 +27,9 @@ RUN apt-get update && apt-get install -y \
 && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m espresso && usermod -a -G www-data espresso
-USER 1000
+USER espresso
+ENV HOME="/home/espresso"
+# install Python3 packages locally
+RUN pip3 install --user cython==0.26 cmake==3.10.3
+ENV PATH="${PATH}:${HOME}/.local/bin"
 WORKDIR /home/espresso


### PR DESCRIPTION
Use versions available in Ubuntu 18.04, as discussed in [es meeting 2019-11-26](https://github.com/espressomd/espresso/wiki/Espresso-meeting-2019-11-26#minimal-required-dependency-versions-for-42).