### PR TITLE
Adapt syntax to the refactored build_cmake.sh

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,6 +42,7 @@ stages:
   script:
     - git clone --depth=1 --recursive https://github.com/espressomd/espresso
     - cd espresso
+    - export make_check_unit_tests=false make_check_python=false
     - maintainer/CI/build_cmake.sh
   variables:
     make_check: "false"
@@ -128,6 +129,7 @@ test/rocm-python3:latest:
   script:
     - git clone --depth=1 --recursive https://github.com/espressomd/espresso
     - cd espresso
+    - export make_check_unit_tests=false make_check_python=false
     - maintainer/CI/build_cmake.sh
     - cd build
     - make python_test_data
@@ -166,6 +168,7 @@ test/ubuntu-python3:cuda-10.1:
   script:
     - git clone --depth=1 --recursive https://github.com/espressomd/espresso
     - cd espresso
+    - export make_check_unit_tests=false make_check_python=false
     - maintainer/CI/build_cmake.sh
     - cd build
     - make sphinx


### PR DESCRIPTION
Fix failing CI on master (side-effect of espressomd/espresso#3326).