### PR TITLE
Intel: disable license check

### DIFF
--- a/docker/intel-python3/Dockerfile-18
+++ b/docker/intel-python3/Dockerfile-18
@@ -24,6 +24,7 @@ RUN cd /usr/local \
 && rm -r /usr/local/man
 
 # Intel Compiler
+ENV INTEL_NO_CONNECTION_CHECK=1
 COPY intel.cfg /tmp/
 RUN cd /tmp \
  && mkdir intel \


### PR DESCRIPTION
As reported by @jngrad (https://github.com/espressomd/docker/pull/153#issuecomment-578421856), the Intel installer seems to have trouble with the license server. According to https://software.intel.com/en-us/articles/troubleshooting-license-manager-problems, the check can be skipped by setting a variable.