### PR TITLE
Update images and add Ubuntu 20.04

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,6 +93,8 @@ intel-python3:19:build:
     - icp
 ubuntu-python3:18.04:build:
   extends: .build_template
+ubuntu-python3:20.04:build:
+  extends: .build_template
 ubuntu-python3:wo-dependencies:build:
   extends: .build_template
 ubuntu-python3:min_boost:build:
@@ -174,6 +176,9 @@ test/intel-python3:19:
 test/ubuntu-python3:18.04:
   extends: .test_template
   needs: ["ubuntu-python3:18.04:build"]
+test/ubuntu-python3:20.04:
+  extends: .test_template
+  needs: ["ubuntu-python3:20.04:build"]
 test/ubuntu-python3:wo-dependencies:
   extends: .test_template
   needs: ["ubuntu-python3:wo-dependencies:build"]
@@ -255,6 +260,9 @@ intel-python3:19:
 ubuntu-python3:18.04:
   extends: .deploy_template
   needs: ["test/ubuntu-python3:18.04"]
+ubuntu-python3:20.04:
+  extends: .deploy_template
+  needs: ["test/ubuntu-python3:20.04"]
 ubuntu-python3:wo-dependencies:
   extends: .deploy_template
   needs: ["test/ubuntu-python3:wo-dependencies"]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ stages:
 .build_template:
   stage: build
   image:
-    name: gcr.io/kaniko-project/executor:debug-v0.15.0
+    name: gcr.io/kaniko-project/executor:debug
     entrypoint: [""]
   before_script:
     - echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_REGISTRY_USER\",\"password\":\"$CI_REGISTRY_PASSWORD\"}}}" > /kaniko/.docker/config.json

--- a/docker/rocm-python3/Dockerfile-latest
+++ b/docker/rocm-python3/Dockerfile-latest
@@ -1,6 +1,7 @@
 FROM rocm/dev-ubuntu-18.04:3.0
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get install -y \
+RUN sed -i 's|repo.radeon.com/rocm/apt/debian/|repo.radeon.com/rocm/apt/3.0/|' /etc/apt/sources.list.d/rocm.list \
+&& apt-get update && apt-get install -y \
     apt-utils \
     cmake \
     build-essential \

--- a/docker/rocm-python3/Dockerfile-latest
+++ b/docker/rocm-python3/Dockerfile-latest
@@ -1,4 +1,4 @@
-FROM rocm/dev-ubuntu-18.04:latest
+FROM rocm/dev-ubuntu-18.04:3.0
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y \
     apt-utils \

--- a/docker/ubuntu-python3/Dockerfile-20.04
+++ b/docker/ubuntu-python3/Dockerfile-20.04
@@ -1,0 +1,43 @@
+FROM ubuntu:focal
+ENV DEBIAN_FRONTEND noninteractive
+COPY build-and-install-scafacos.sh /tmp/
+RUN apt-get update && apt-get install -y \
+    apt-utils \
+    cmake \
+    ccache \
+    autoconf \
+    gfortran \
+    build-essential \
+    pkg-config \
+    openmpi-bin \
+    libopenmpi-dev \
+    clang-9 \
+    clang-tidy-9 \
+    clang-format-9 \
+    libfftw3-dev \
+    libboost-dev libboost-serialization-dev libboost-mpi-dev libboost-filesystem-dev libboost-test-dev \
+    libgsl-dev \
+    cython3 \
+    python3 \
+    python3-numpy \
+    python3-scipy \
+    python3-h5py \
+    python3-vtk7 \
+    python3-setuptools \
+    libhdf5-openmpi-dev \
+    libhdf5-openmpi-103:amd64 \
+    libhdf5-103:amd64 \
+    libblas-dev \
+    liblapack-dev \
+    vim \
+    gdb \
+    curl \
+    lcov \
+    git \
+    jq \
+&& apt-get clean \
+&& rm -rf /var/lib/apt/lists/*
+RUN bash /tmp/build-and-install-scafacos.sh
+RUN useradd -m espresso
+USER 1000
+WORKDIR /home/espresso


### PR DESCRIPTION
Description of changes:
- use the latest kaniko version
- rollback to ROCm 3.0 (fixes #156)
- add an Ubuntu 20.04 image (required for espressomd/espresso#2701 and espressomd/espresso#3445)