### PR TITLE
Roll back to kaniko 0.15

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,7 +84,9 @@ intel-python3:18:build:
     - nofirewall
     - icp
 intel-python3:19:build:
-  extends: .build_template
+  extends:
+    - .build_template
+    - .manual_template
   timeout: 6h
   tags:
     - docker
@@ -171,8 +173,13 @@ test/intel-python3:18:
     - linux
     - icp
 test/intel-python3:19:
-  extends: .test_template
-  needs: ["intel-python3:19:build"]
+  extends:
+    - .test_template
+    - .manual_template
+  tags:
+    - docker
+    - linux
+    - icp
 test/ubuntu-python3:18.04:
   extends: .test_template
   needs: ["ubuntu-python3:18.04:build"]
@@ -255,8 +262,14 @@ intel-python3:18:
     - nofirewall
     - icp
 intel-python3:19:
-  extends: .deploy_template
-  needs: ["test/intel-python3:19"]
+  extends:
+    - .deploy_template
+    - .manual_template
+  tags:
+    - docker
+    - linux
+    - nofirewall
+    - icp
 ubuntu-python3:18.04:
   extends: .deploy_template
   needs: ["test/ubuntu-python3:18.04"]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ stages:
 .build_template:
   stage: build
   image:
-    name: gcr.io/kaniko-project/executor:debug-v0.18.0
+    name: gcr.io/kaniko-project/executor:debug-v0.15.0
     entrypoint: [""]
   before_script:
     - echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_REGISTRY_USER\",\"password\":\"$CI_REGISTRY_PASSWORD\"}}}" > /kaniko/.docker/config.json


### PR DESCRIPTION
The cached layers still lead to corrupted images in the build stage with kaniko v0.18 and v0.19.