### PR TITLE
Updated ROCm to latest

### DIFF
--- a/docker/Dockerfile-rocm
+++ b/docker/Dockerfile-rocm
@@ -1,6 +1,6 @@
-FROM rocm/dev-ubuntu-18.04:3.0
+FROM rocm/dev-ubuntu-18.04:latest
 ENV DEBIAN_FRONTEND noninteractive
-RUN sed -i 's|repo.radeon.com/rocm/apt/debian/|repo.radeon.com/rocm/apt/3.0/|' /etc/apt/sources.list.d/rocm.list \
+#RUN sed -i 's|repo.radeon.com/rocm/apt/debian/|repo.radeon.com/rocm/apt/3.0/|' /etc/apt/sources.list.d/rocm.list \
 && apt-get update && apt-get install -y \
     apt-utils \
     cmake \


### PR DESCRIPTION
Since https://github.com/espressomd/espresso/pull/3623, this should work now. I commented out the `sed` line because we might need it again in the future.

I have no idea how testing works now that @KaiSzuttor's changes are merged, so please do whatever is necessary.