### PR TITLE
Make the Ubuntu 20.04 image CUDA-capable

### DIFF
--- a/docker/Dockerfile-ubuntu-20.04
+++ b/docker/Dockerfile-ubuntu-20.04
@@ -5,8 +5,15 @@ COPY ubuntu-packages.txt /tmp
 RUN apt-get update && xargs -a /tmp/ubuntu-packages.txt apt-get install -y \
     && apt-get install -y \
     clang-9 clang-tidy-9 clang-format-9 \
+    gcc-8 g++-8 \
+    gcc-9 g++-9 \
+    libthrust-dev \
+    nvidia-cuda-toolkit \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN bash /tmp/build-and-install-scafacos.sh
+
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 
 RUN useradd -m espresso
 USER espresso


### PR DESCRIPTION
Required for espressomd/espresso#3627