### PR TITLE
Install llvm-symbolizer

### DIFF
--- a/docker/Dockerfile-ubuntu-20.04
+++ b/docker/Dockerfile-ubuntu-20.04
@@ -4,7 +4,7 @@ COPY build-and-install-scafacos.sh /tmp
 COPY ubuntu-packages.txt /tmp
 RUN apt-get update && xargs -a /tmp/ubuntu-packages.txt apt-get install --no-install-recommends -y \
     && apt-get install -y --no-install-recommends \
-    clang-9 clang-tidy-9 clang-format-9 \
+    clang-9 clang-tidy-9 clang-format-9 llvm-9 \
     doxygen \
     ffmpeg \
     gcc-8 g++-8 \


### PR DESCRIPTION
ASAN output generates a warning and an incomplete trace when `llvm-symbolizer` is unavailable.