### PR TITLE
Update CUDA 10 image to CMake 3.13

### DIFF
--- a/docker/intel-python3/Dockerfile-19
+++ b/docker/intel-python3/Dockerfile-19
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y \
 
 # CMake
 RUN cd /usr/local \
-&& curl -sL https://cmake.org/files/v3.11/cmake-3.11.0-Linux-x86_64.tar.gz | tar --strip-components=1 -xz \
+&& curl -sL https://cmake.org/files/v3.13/cmake-3.13.0-Linux-x86_64.tar.gz | tar --strip-components=1 -xz \
 && rm -r /usr/local/man
 
 # Intel Compiler

--- a/docker/ubuntu-python3/Dockerfile-cuda-10.1
+++ b/docker/ubuntu-python3/Dockerfile-cuda-10.1
@@ -54,7 +54,7 @@ RUN tlmgr init-usertree \
 && updmap -user
 
 # install Python3 packages locally
-RUN pip3 install --user --upgrade 'sphinx>=2.0,!=2.1.0,!=3.0.0' sphinxcontrib-bibtex 'MDAnalysis==0.16' 'pint>=0.9'
+RUN pip3 install --user --upgrade 'sphinx>=2.0,!=2.1.0,!=3.0.0' sphinxcontrib-bibtex 'MDAnalysis==0.16' 'pint>=0.9' 'Biopython==1.76'
 ENV PATH="/home/espresso/.local/bin:${PATH}"
 
 WORKDIR /home/espresso


### PR DESCRIPTION
Required for espressomd/espresso#3445

Old CMake versions are not compatible with CUDA 10 and fail to find library `cublas`.