### PR TITLE
Bump numpy version in CentOS 7 (NEP 29)

### DIFF
--- a/docker/Dockerfile-centos
+++ b/docker/Dockerfile-centos
@@ -32,5 +32,5 @@ RUN useradd -m espresso -u 1000
 USER 1000
 ENV HOME="/home/espresso"
 # install Python3 packages locally
-RUN pip3 install --user h5py
+RUN pip3 install --user h5py 'numpy==1.14.0'
 WORKDIR /home/espresso

--- a/docker/Dockerfile-debian
+++ b/docker/Dockerfile-debian
@@ -1,6 +1,6 @@
 FROM debian:buster
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-utils \
     build-essential \
     ccache \


### PR DESCRIPTION
Required for espressomd/espresso#3421