### PR TITLE
Create CUDA 11 image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: ['centos', 'debian', 'fedora', 'opensuse', 'rocm',
+        image: ['centos', 'debian', 'fedora', 'opensuse', 'rocm', 'cuda',
                 'ubuntu-18.04', 'ubuntu-20.04', 'ubuntu-wo-dependencies']
     steps:
     - uses: actions/checkout@master

--- a/docker/Dockerfile-cuda
+++ b/docker/Dockerfile-cuda
@@ -1,0 +1,17 @@
+FROM nvidia/cuda:11.0-devel-ubuntu20.04
+ENV DEBIAN_FRONTEND noninteractive
+COPY build-and-install-scafacos.sh /tmp
+COPY ubuntu-packages.txt /tmp
+RUN apt-get update && xargs -a /tmp/ubuntu-packages.txt apt-get install --no-install-recommends -y \
+    && apt-get install --no-install-recommends -y \
+    libthrust-dev \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN bash /tmp/build-and-install-scafacos.sh
+
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+
+RUN useradd -m espresso
+USER espresso
+WORKDIR /home/espresso

--- a/docker/Dockerfile-ubuntu-20.04
+++ b/docker/Dockerfile-ubuntu-20.04
@@ -3,7 +3,7 @@ ENV DEBIAN_FRONTEND noninteractive
 COPY build-and-install-scafacos.sh /tmp
 COPY ubuntu-packages.txt /tmp
 RUN apt-get update && xargs -a /tmp/ubuntu-packages.txt apt-get install --no-install-recommends -y \
-    && apt-get install -y --no-install-recommends \
+    && apt-get install --no-install-recommends -y \
     clang-9 clang-tidy-9 clang-format-9 llvm-9 \
     doxygen \
     ffmpeg \
@@ -13,7 +13,7 @@ RUN apt-get update && xargs -a /tmp/ubuntu-packages.txt apt-get install --no-ins
     ipython3 jupyter-notebook jupyter-nbconvert \
     libthrust-dev \
     nvidia-cuda-toolkit \
-    python3-lxml python3-matplotlib \
+    python3-matplotlib \
     texlive-base \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile-ubuntu-wo-dependencies
+++ b/docker/Dockerfile-ubuntu-wo-dependencies
@@ -1,6 +1,6 @@
 FROM ubuntu:focal
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install --no-install-recommends -y \
     apt-utils \
     build-essential \
     curl \
@@ -14,10 +14,12 @@ RUN apt-get update && apt-get install -y \
     openssh-client \
     openmpi-bin \
     python3 \
-    python3-numpy \
-    python3-scipy \
+    python3-dev \
     python3-h5py \
+    python3-lxml \
+    python3-numpy \
     python3-pip \
+    python3-scipy \
     python3-setuptools \
     python3-vtk7 \
     vim \


### PR DESCRIPTION
Required for espressomd/espresso#3611. Relies on an NVIDIA-supplied docker image instead of Ubuntu packages.