### PR TITLE
Install a newer version of scipy

### DIFF
--- a/docker/Dockerfile-ubuntu-20.04
+++ b/docker/Dockerfile-ubuntu-20.04
@@ -36,6 +36,7 @@ RUN pip3 install --user \
   pre-commit \
   'sphinx>=2.0,!=2.1.0,!=3.0.0' \
   sphinxcontrib-bibtex \
+  scipy==1.6.0 \
   'MDAnalysis>=0.18' \
   'pint>=0.9'
 WORKDIR /home/espresso


### PR DESCRIPTION
CI isn't running the first test in `testsuite/python/rotation.py` due to the outdated scipy version available in Ubuntu 20.04.