### PR TITLE
Fix Ubuntu images

### DIFF
--- a/docker/Dockerfile-cuda
+++ b/docker/Dockerfile-cuda
@@ -15,6 +15,6 @@ ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 RUN useradd -m espresso
 USER espresso
 ENV HOME="/home/espresso"
-ENV PATH="${PATH:+$PATH:}${HOME}/.local/bin"
+ENV PATH="${HOME}/.local/bin${PATH:+:$PATH}"
 RUN pip3 install --user scipy==1.6.0
 WORKDIR /home/espresso

--- a/docker/Dockerfile-ubuntu-20.04
+++ b/docker/Dockerfile-ubuntu-20.04
@@ -26,7 +26,7 @@ ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 RUN useradd -m espresso
 USER espresso
 ENV HOME="/home/espresso"
-ENV PATH="${PATH:+$PATH:}${HOME}/.local/bin"
+ENV PATH="${HOME}/.local/bin${PATH:+:$PATH}"
 RUN pip3 install --user \
   autopep8==1.5.0 \
   pycodestyle==2.5.0 \

--- a/docker/Dockerfile-ubuntu-20.04
+++ b/docker/Dockerfile-ubuntu-20.04
@@ -12,6 +12,7 @@ RUN apt-get update && xargs -a /tmp/ubuntu-packages.txt apt-get install --no-ins
     graphviz \
     ipython3 jupyter-notebook jupyter-nbconvert \
     libthrust-dev \
+    libnvidia-compute-460-server \
     nvidia-cuda-toolkit \
     python3-matplotlib \
     python3-pint \

--- a/docker/Dockerfile-ubuntu-wo-dependencies
+++ b/docker/Dockerfile-ubuntu-wo-dependencies
@@ -29,6 +29,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 RUN useradd -m espresso
 USER 1000
 ENV HOME="/home/espresso"
-ENV PATH="${PATH:+$PATH:}${HOME}/.local/bin"
+ENV PATH="${HOME}/.local/bin${PATH:+:$PATH}"
 RUN pip3 install --user scipy==1.6.0
 WORKDIR /home/espresso


### PR DESCRIPTION
Pin `libnvidia-compute-460-server` package, otherwise the 470 version from `focal-update` is installed, which is incompatible with host machines that have CUDA driver 460.91.03 and CUDA version 11.2. Update `$PATH` to search for pip-installed python packages before searching for Ubuntu python packages.