### PR TITLE
Update dependencies

### DIFF
--- a/docker/Dockerfile-ubuntu-20.04
+++ b/docker/Dockerfile-ubuntu-20.04
@@ -35,7 +35,7 @@ RUN pip3 install --user \
   pylint==2.4.4 \
   astroid==2.3.3 \
   isort==4.3.4 \
-  cmake-format==0.6.11 \
+  cmakelang==0.6.13 \
   pre-commit==2.15.0 \
   sphinx==4.2.0 \
   sphinx-toggleprompt==0.0.5 \

--- a/docker/build-and-install-scafacos.sh
+++ b/docker/build-and-install-scafacos.sh
@@ -8,7 +8,7 @@ cd scafacos
 ./bootstrap
 ./configure --enable-shared --enable-portable-binary \
 	--with-internal-pfft --with-internal-pnfft \
-	--enable-fcs-solvers=direct,pnfft,p2nfft,p3m \
+	--enable-fcs-solvers=direct,pnfft,p2nfft,p3m,ewald \
 	--disable-fcs-fortran --enable-fcs-dipoles
 make -j `nproc`
 make install


### PR DESCRIPTION
Description of changes:
- build ScaFaCoS with Ewald support: a method that doesn't support near-field delegation is needed to fully test the ScaFaCoS bridge in ESPResSo, and the Ewald method is one of the few methods that satisfy this requirement
- replace deprecated Python package `cmake-format`, which is not packaged in Ubuntu, by `cmakelang`, which is packaged in Ubuntu 21.04 and later versions; `cmakelang` provides a `cmake-format` as a backward-compatible sub-command