### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: ['debian', 'fedora', 'cuda', 'ubuntu-20.04', 'ubuntu-wo-dependencies']
+        image: ['debian', 'fedora', 'cuda', 'ubuntu-20.04', 'ubuntu-22.04', 'ubuntu-wo-dependencies']
     steps:
     - uses: actions/checkout@master
     - name: Build and deploy

--- a/docker/Dockerfile-cuda
+++ b/docker/Dockerfile-cuda
@@ -2,6 +2,11 @@ FROM nvidia/cuda:11.0-devel-ubuntu20.04
 ENV DEBIAN_FRONTEND noninteractive
 COPY build-and-install-scafacos.sh /tmp
 COPY ubuntu-packages.txt /tmp
+RUN rm /etc/apt/sources.list.d/cuda.list \
+    && apt-key del 7fa2af80 \
+    && curl --silent -LO https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb \
+    && dpkg -i cuda-keyring_1.0-1_all.deb \
+    && rm cuda-keyring_1.0-1_all.deb
 RUN apt-get update && xargs -a /tmp/ubuntu-packages.txt apt-get install --no-install-recommends -y \
     && apt-get install --no-install-recommends -y \
     libthrust-dev \

--- a/docker/Dockerfile-cuda
+++ b/docker/Dockerfile-cuda
@@ -16,5 +16,5 @@ RUN useradd -m espresso
 USER espresso
 ENV HOME="/home/espresso"
 ENV PATH="${HOME}/.local/bin${PATH:+:$PATH}"
-RUN pip3 install --user scipy==1.6.0
+RUN pip3 install --no-cache --user scipy==1.6.0
 WORKDIR /home/espresso

--- a/docker/Dockerfile-fedora
+++ b/docker/Dockerfile-fedora
@@ -1,4 +1,4 @@
-FROM fedora:34
+FROM fedora:36
 RUN dnf -y install \
   blas-devel \
   boost-devel \

--- a/docker/Dockerfile-ubuntu-20.04
+++ b/docker/Dockerfile-ubuntu-20.04
@@ -29,7 +29,7 @@ RUN useradd -m espresso
 USER espresso
 ENV HOME="/home/espresso"
 ENV PATH="${HOME}/.local/bin${PATH:+:$PATH}"
-RUN pip3 install --user \
+RUN pip3 install --no-cache --user \
   autopep8==1.5.0 \
   pycodestyle==2.5.0 \
   pylint==2.4.4 \
@@ -40,6 +40,7 @@ RUN pip3 install --user \
   sphinx==4.2.0 \
   sphinx-toggleprompt==0.0.5 \
   sphinxcontrib-bibtex==2.4.1 \
+  numpydoc==0.7.0 \
   scipy==1.7.1 \
   MDAnalysis==1.1.1
 WORKDIR /home/espresso

--- a/docker/Dockerfile-ubuntu-22.04
+++ b/docker/Dockerfile-ubuntu-22.04
@@ -1,0 +1,37 @@
+FROM ubuntu:jammy
+ENV DEBIAN_FRONTEND noninteractive
+COPY build-and-install-scafacos.sh /tmp
+COPY ubuntu-packages.txt /tmp
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        doxygen \
+        gcc-10 g++-10 \
+        clang-12 clang-tidy-12 clang-format-12 llvm-12 \
+        libthrust-dev \
+        nvidia-cuda-toolkit \
+        pylint \
+        python3-autopep8 \
+        python3-matplotlib \
+        python3-pint \
+        python3-pycodestyle \
+        python3-tqdm \
+        $(cat /tmp/ubuntu-packages.txt) && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && rm /tmp/ubuntu-packages.txt
+
+RUN bash /tmp/build-and-install-scafacos.sh
+
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+
+RUN useradd -m espresso
+USER espresso
+ENV HOME="/home/espresso"
+ENV PATH="${HOME}/.local/bin${PATH:+:$PATH}"
+RUN pip3 install --no-cache --user \
+  cmakelang==0.6.13 \
+  pre-commit==2.15.0 \
+  sphinx==4.5.0 \
+  sphinx-toggleprompt==0.0.5 \
+  sphinxcontrib-bibtex==2.4.2 \
+  numpydoc==0.7.0
+WORKDIR /home/espresso

--- a/docker/Dockerfile-ubuntu-wo-dependencies
+++ b/docker/Dockerfile-ubuntu-wo-dependencies
@@ -30,5 +30,5 @@ RUN useradd -m espresso
 USER 1000
 ENV HOME="/home/espresso"
 ENV PATH="${HOME}/.local/bin${PATH:+:$PATH}"
-RUN pip3 install --user scipy==1.6.0
+RUN pip3 install --no-cache --user scipy==1.6.0
 WORKDIR /home/espresso

--- a/docker/build-and-install-scafacos.sh
+++ b/docker/build-and-install-scafacos.sh
@@ -3,15 +3,31 @@
 set -e
 
 cd /tmp
-git clone --recursive https://github.com/scafacos/scafacos.git --branch dipoles
+git clone --recursive --branch dipoles https://github.com/scafacos/scafacos.git
 cd scafacos
+
+# get a stable revision in the dipoles branch
+git checkout -b patches 066f753f0572c7397508231cb4fc9432d5aeaf04
+# fix diagnostics from GCC >= 10.0 (scafacos/scafacos#31)
+git cherry-pick -n ef7268c3c75cfbdde02392d7af9dfb11a0a386fd
+# MMM2D energy bugfix (scafacos/scafacos#32)
+git cherry-pick -n 4cd4699d33ad173484512897ceff41debbb28793
+# remove deprecated MPI functions (scafacos/scafacos@v1.0.2)
+git cherry-pick -n 39b68e77ec9619282eaf63b986a4f9ef532e6609
+git cherry-pick -n be416261bc0ff9c7406b4114515c97af73a70f47
+# Ewald tuning bugfix (scafacos/scafacos#36)
+git fetch origin pull/36/head
+git cherry-pick -n a752a05761f6624076373d7a6c33d1c80c2f85eb
+# remove unused Cython file that fails to install
+sed -i 's/ scafacos.pyx / /' python/Makefile.am
+
 ./bootstrap
 ./configure --enable-shared --enable-portable-binary \
 	--with-internal-pfft --with-internal-pnfft \
 	--enable-fcs-solvers=direct,pnfft,p2nfft,p3m,ewald \
 	--disable-fcs-fortran --enable-fcs-dipoles
-make -j `nproc`
+make -j $(nproc)
 make install
 cd
-rm -rf /tmp/scafacos
+rm -rf /tmp/scafacos /tmp/build-and-install-scafacos.sh
 ldconfig

--- a/docker/ubuntu-packages.txt
+++ b/docker/ubuntu-packages.txt
@@ -26,7 +26,6 @@ python3
 python3-coverage
 python3-dev
 python3-numpy
-python3-numpydoc
 python3-scipy
 python3-h5py
 python3-pip


### PR DESCRIPTION
Add an Ubuntu 22.04 image, update GPG keys, backport ScaFaCoS improvements from release v1.0.2 into the dipoles branch.