### PR TITLE
Install new codecov dependencies

### DIFF
--- a/docker/Dockerfile-cuda
+++ b/docker/Dockerfile-cuda
@@ -1,9 +1,10 @@
-FROM nvidia/cuda:11.0-devel-ubuntu20.04
+FROM nvidia/cuda:11.0.3-devel-ubuntu20.04
 ENV DEBIAN_FRONTEND noninteractive
 COPY install-pfft.sh /tmp
 COPY install-scafacos.sh /tmp
 COPY ubuntu-packages.txt /tmp
-RUN rm /etc/apt/sources.list.d/cuda.list \
+RUN apt-get update && apt-get install --no-install-recommends -y curl \
+    && rm /etc/apt/sources.list.d/cuda.list \
     && apt-key del 7fa2af80 \
     && curl --silent -LO https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb \
     && dpkg -i cuda-keyring_1.0-1_all.deb \

--- a/docker/ubuntu-packages.txt
+++ b/docker/ubuntu-packages.txt
@@ -9,10 +9,12 @@ cython3
 gfortran
 gdb
 git
+gnupg
 jq
 lcov
 libblas-dev
 libboost-dev libboost-serialization-dev libboost-mpi-dev libboost-filesystem-dev libboost-test-dev
+libdigest-sha-perl
 libfftw3-dev
 libfftw3-mpi-dev
 libgsl-dev


### PR DESCRIPTION
The new codecov uploader has a PGP-signed SHA sum that needs to be checked before running the executable:
https://docs.codecov.com/docs/codecov-uploader#integrity-checking-the-uploader