### PR TITLE
Configure nbconvert for deployment on GitHub Pages

### DIFF
--- a/docker/Dockerfile-ubuntu-22.04
+++ b/docker/Dockerfile-ubuntu-22.04
@@ -77,6 +77,7 @@ ENV HOME="/home/espresso"
 ENV PATH="${HOME}/.local/bin${PATH:+:$PATH}"
 RUN pip3 install --no-cache --user \
   pre-commit==2.17.0 \
+  nbconvert==6.4.5 \
   sphinx==4.5.0 \
   sphinx-toggleprompt==0.2.0 \
   sphinxcontrib-bibtex==2.5.0 \


### PR DESCRIPTION
Pre-requisite for espressomd/espresso#4651

Jupyter and nbconvert now produce HTML tutorials that source their JavaScript dependencies from cloud providers instead of from the hard drive.