### PR TITLE
Fix portability issues in pfft

### DIFF
--- a/docker/install-pfft.sh
+++ b/docker/install-pfft.sh
@@ -12,7 +12,7 @@ cd pfft-${pfft_version}
 ./bootstrap.sh
 mkdir build
 cd build
-../configure --prefix=/usr/local
+../configure --prefix=/usr/local --enable-portable-binary
 make -j $(nproc)
 make install
 cd


### PR DESCRIPTION
Replace `-march=native` by `-mtune=native` to avoid illegal instructions on unsupported hardware.