### PR TITLE
Migrate from DockerHub registry to GitHub registry

### DIFF
--- a/.github/actions/docker/action.yml
+++ b/.github/actions/docker/action.yml
@@ -1,4 +1,3 @@
-# action.yml
 name: 'docker'
 description: 'Build and deploy docker images'
 inputs:
@@ -17,12 +16,6 @@ inputs:
   tag:
     description: 'Tag for the image'
     required: true
-  dockerhub_user:
-    description: 'Username on dockerhub for second deploy'
-    required: false
-  dockerhub_password:
-    description: 'Password for dockerhub registry.'
-    required: false
   build_args:
     description: 'List of build arguments.'
     required: false
@@ -35,6 +28,4 @@ runs:
     - ${{ inputs.password }}
     - ${{ inputs.event_name }}
     - ${{ inputs.tag }}
-    - ${{ inputs.dockerhub_user }}
-    - ${{ inputs.dockerhub_password }}
     - ${{ inputs.build_args }}

--- a/.github/actions/docker/entrypoint.sh
+++ b/.github/actions/docker/entrypoint.sh
@@ -7,8 +7,6 @@ project=$(echo "$2" | cut -d'/' -f2)
 password=$3
 event_name=$4
 tag=$5
-dockerhub_user=$6
-dockerhub_password=$7
 
 echo "Log in to registry."
 echo "${password}" | docker login -u "${username}" --password-stdin docker.pkg.github.com || exit 1
@@ -18,14 +16,9 @@ full_tag="docker.pkg.github.com/${username}/${project}/${image}:${tag}"
 echo "Building image with tag: ${full_tag}"
 docker build docker -t "${full_tag}" -f "docker/Dockerfile-${image}" || exit 1
 
-if [ "${event_name}" != "pull_request" ]; then
+if [ "${event_name}" = "pull_request" ]; then
+    echo "Pull request: not pushing to registry."
+else
     echo "Pushing to registry."
     docker push "${full_tag}" || exit 1
-    if [ "${dockerhub_user}" != "" ]; then
-        echo "${dockerhub_password}" | docker login -u "${dockerhub_user}" --password-stdin || exit 1
-        docker tag "${full_tag}" "${username}/${project}-${image}:${tag}"
-        docker push "${username}/${project}-${image}:${tag}" || exit 1
-    fi  
-else
-    echo "Pull request: not pushing to registry."
 fi

--- a/.github/actions/docker/entrypoint.sh
+++ b/.github/actions/docker/entrypoint.sh
@@ -12,13 +12,25 @@ echo "Log in to registry."
 echo "${password}" | docker login -u "${username}" --password-stdin docker.pkg.github.com || exit 1
 
 full_tag="docker.pkg.github.com/${username}/${project}/${image}:${tag}"
+dockerfile="docker/Dockerfile-${image}"
+full_tag_github_action=""
+if grep -q "FROM image_base AS image_standalone" "${dockerfile}"; then
+  full_tag_github_action="${full_tag}-base-layer"
+fi
 
 echo "Building image with tag: ${full_tag}"
-docker build docker -t "${full_tag}" -f "docker/Dockerfile-${image}" || exit 1
+docker build docker -t "${full_tag}" -f "${dockerfile}" || exit 1
+if [ ! -z "${full_tag_github_action}" ]; then
+  echo "Building GitHub Action-specific image with tag: ${full_tag_github_action}"
+  docker build docker -t "${full_tag_github_action}" -f "${dockerfile}" --target image_base || exit 1
+fi
 
 if [ "${event_name}" = "pull_request" ]; then
     echo "Pull request: not pushing to registry."
 else
     echo "Pushing to registry."
     docker push "${full_tag}" || exit 1
+    if [ ! -z "${full_tag_github_action}" ]; then
+      docker push "${full_tag_github_action}" || exit 1
+    fi
 fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,5 +20,3 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
         event_name: ${{ github.event_name }}
         tag: ${{ github.sha }}
-        dockerhub_user: ${{ secrets.DOCKERHUB_USERNAME }}
-        dockerhub_password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/docker/Dockerfile-debian
+++ b/docker/Dockerfile-debian
@@ -1,7 +1,6 @@
 FROM debian:bullseye
-ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apt-utils \
         build-essential \
         curl \

--- a/docker/Dockerfile-debian
+++ b/docker/Dockerfile-debian
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:bullseye AS image_base
 RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -27,6 +27,7 @@ RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+FROM image_base AS image_standalone
 RUN useradd -m espresso
 USER espresso
 WORKDIR /home/espresso

--- a/docker/Dockerfile-debian
+++ b/docker/Dockerfile-debian
@@ -1,19 +1,17 @@
 FROM debian:bullseye
-RUN apt-get update && \
+RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list && \
+    apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apt-utils \
         build-essential \
         curl \
         ccache \
-        cmake \
         cython3 \
         gdb \
         git \
-        libblas-dev \
         libboost-dev libboost-serialization-dev libboost-mpi-dev libboost-filesystem-dev libboost-test-dev \
         libfftw3-dev \
         libhdf5-openmpi-dev \
-        liblapack-dev \
         libpython3-dev \
         openmpi-bin \
         python3 \
@@ -24,6 +22,8 @@ RUN apt-get update && \
         python3-setuptools \
         python3-vtk9 \
         vim && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --target-release bullseye-backports \
+        cmake && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile-ubuntu-22.04
+++ b/docker/Dockerfile-ubuntu-22.04
@@ -1,9 +1,8 @@
 FROM ubuntu:jammy
-ENV DEBIAN_FRONTEND noninteractive
 COPY install-pfft.sh /tmp
 COPY install-scafacos.sh /tmp
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
         apt-utils \
         autoconf \
         automake \

--- a/docker/Dockerfile-ubuntu-wo-dependencies
+++ b/docker/Dockerfile-ubuntu-wo-dependencies
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy
+FROM ubuntu:jammy AS image_base
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
         apt-utils \
@@ -27,6 +27,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+FROM image_base AS image_standalone
 RUN useradd -m espresso
 USER espresso
 WORKDIR /home/espresso

--- a/docker/Dockerfile-ubuntu-wo-dependencies
+++ b/docker/Dockerfile-ubuntu-wo-dependencies
@@ -1,7 +1,6 @@
 FROM ubuntu:jammy
-ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
         apt-utils \
         build-essential \
         curl \


### PR DESCRIPTION
Description of changes:
-  no longer push images to the DockerHub [espressomd](https://hub.docker.com/u/espressomd) organization
- generate a more compact Debian image without Stokesian Dynamics dependencies to reduce pull times
- generate images suitable for GitHub Actions (without a USER layer) with a special tag
   - generating alternative versions that work out-of-the-box for Docker users (helps with debugging)