### PR TITLE
Make ScaFaCoS code portable on x86_64 CI runners

### DIFF
--- a/docker/install-pfft.sh
+++ b/docker/install-pfft.sh
@@ -12,7 +12,7 @@ cd pfft-${pfft_version}
 ./bootstrap.sh
 mkdir build
 cd build
-../configure --prefix=/usr/local --enable-portable-binary
+../configure --prefix=/usr/local --enable-portable-binary --with-gcc-arch=x86_64
 make -j $(nproc)
 make install
 cd

--- a/docker/install-scafacos.sh
+++ b/docker/install-scafacos.sh
@@ -27,11 +27,12 @@ mkdir build
 cd build
 ../configure --enable-shared \
              --enable-portable-binary \
+             --with-gcc-arch=x86_64 \
              --enable-fcs-dipoles \
              --enable-fcs-solvers=direct,p2nfft,p3m,ewald \
              --disable-fcs-fortran \
-             --with-internal-fftw=yes \
-             --with-internal-pfft=yes \
+             --with-internal-fftw=no \
+             --with-internal-pfft=no \
              --with-internal-pnfft=yes \
              --prefix=/usr/local
 make -j $(nproc)


### PR DESCRIPTION
The `-mtune=native` compiler flag would trigger SIGILL when running a container on an AMD host machine when the image was generated on an Intel host machine.