### PR TITLE
Update ESPResSo dependencies

### DIFF
--- a/docker/Dockerfile-fedora
+++ b/docker/Dockerfile-fedora
@@ -13,6 +13,7 @@ RUN dnf -y install \
   gdb \
   git \
   hdf5-mpich-devel \
+  jq \
   lapack-devel \
   make \
   mpich-devel \

--- a/docker/Dockerfile-ubuntu
+++ b/docker/Dockerfile-ubuntu
@@ -50,6 +50,7 @@ RUN apt-get update && \
         python3 \
         python3-dev \
         pylint \
+        python3-ase \
         python3-coverage \
         python3-dev \
         python3-h5py \
@@ -60,6 +61,7 @@ RUN apt-get update && \
         python3-nbconvert \
         python3-numpy \
         python3-numpydoc \
+        python3-pandas \
         python3-pint \
         python3-pip \
         python3-packaging \

--- a/docker/Dockerfile-ubuntu
+++ b/docker/Dockerfile-ubuntu
@@ -110,15 +110,9 @@ RUN cd "${HOME}" && \
     autopep8==2.1.0 \
     pycodestyle==2.11.1 \
     sphinx-toggleprompt==0.5.2 && \
-  jupyter_config_root=$(jupyter --paths --json | jq ".config[0]") && \
-  jupyter_config_root=${jupyter_config_root#\"} && \
-  jupyter_config_root=${jupyter_config_root%\"} && \
-  jupyter_kernels_root=$(jupyter --paths --json | jq ".data[0]")/kernels && \
-  jupyter_kernels_root=${jupyter_kernels_root#\"} && \
-  jupyter_kernels_root=${jupyter_kernels_root%\"} && \
-  mkdir -p "${jupyter_config_root}" "${jupyter_kernels_root}" && \
+  jupyter_config_root=$(jupyter --paths --json | jq -r ".config[0]") && \
+  mkdir -p "${jupyter_config_root}" && \
   mv "/tmp/jupyter_nbconvert_config.json" "${jupyter_config_root}/" && \
-  ln -s "${VIRTUAL_ENV}/share/jupyter/kernels/python3" "${jupyter_kernels_root}/python3" && \
   deactivate && \
   mkdir -p "${HOME}/.local/bin" && \
   mkdir -p "${HOME}/.local/etc/alternatives" && \

--- a/docker/install-kokkos.sh
+++ b/docker/install-kokkos.sh
@@ -8,7 +8,7 @@ git clone -b 4.3.00 https://github.com/kokkos/kokkos
 cd kokkos/
 mkdir build
 cd build/
-cmake ..  -D Kokkos_ENABLE_CUDA=OFF -DKokkos_ENABLE_OPENMP=ON
+cmake ..  -D Kokkos_ENABLE_CUDA=OFF -DKokkos_ENABLE_OPENMP=ON -D CMAKE_POSITION_INDEPENDENT_CODE=ON
 make -j $(nproc) install
 cd
 rm -r /tmp/kokkos

--- a/docker/install-scafacos.sh
+++ b/docker/install-scafacos.sh
@@ -37,6 +37,9 @@ cd build
              --prefix=/usr/local
 make -j $(nproc)
 make install
+# remove GCC version-specific library path to avoid library version mismatch at
+# link or runtime when a different GCC version was used to compile client code
+sed -i -r 's| -L/usr/lib/gcc/x86_64-linux-gnu/[0-9]+ | |' /usr/local/lib/pkgconfig/scafacos.pc
 cd
 rm -r /tmp/scafacos
 ldconfig

--- a/docker/jupyter_nbconvert_config.json
+++ b/docker/jupyter_nbconvert_config.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "Exporter": {
+  "HTMLExporter": {
     "require_js_url": "https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js",
     "mathjax_url": "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/latest.js?config=TeX-AMS_CHTML-full,Safe"
   }


### PR DESCRIPTION
Description of changes:
- resolve ScaFaCoS linker warnings
- resolve JupyterLab environment warnings
- add missing `jq` dependency for the espresso-ci bot
- add `ase` for machine-learned potentials
- add `pandas` for data frames in tutorials