### PR TITLE
Add extra dependencies to Fedora and Ubuntu images

### DIFF
--- a/docker/Dockerfile-fedora
+++ b/docker/Dockerfile-fedora
@@ -13,11 +13,16 @@ RUN dnf -y install \
   gcc-c++ \
   gdb \
   git \
+  gsl-devel \
   hdf5-mpich-devel \
+  heffte-mpich-devel \
+  hwloc-devel \
+  kokkos-devel \
   lapack-devel \
   make \
   mpich-devel \
   ninja-build \
+  NLopt-devel \
   patch \
   python3 \
   python3-devel \

--- a/docker/Dockerfile-ubuntu
+++ b/docker/Dockerfile-ubuntu
@@ -30,7 +30,6 @@ RUN apt-get update && \
         lcov \
         libblas-dev \
         libboost-dev \
-        libboost-filesystem-dev \
         libboost-mpi-dev \
         libboost-serialization-dev \
         libboost-test-dev \
@@ -50,14 +49,14 @@ RUN apt-get update && \
         perl \
         pkg-config \
         pre-commit \
-        python3 \
-        python3-dev \
         pylint \
+        python3 \
         python3-ase \
         python3-coverage \
         python3-dev \
         python3-h5py \
         python3-ipykernel \
+        python3-ipywidgets \
         python3-jinja2 \
         python3-lxml \
         python3-matplotlib \

--- a/docker/Dockerfile-ubuntu-wo-dependencies
+++ b/docker/Dockerfile-ubuntu-wo-dependencies
@@ -12,7 +12,6 @@ RUN apt-get update && \
         gdb \
         git \
         libboost-dev \
-        libboost-filesystem-dev \
         libboost-mpi-dev \
         libboost-serialization-dev \
         libboost-test-dev \


### PR DESCRIPTION
Description of changes:
- add hwloc, kokkos, heFFTe, GSL, and NLopt to the Fedora image
- add Python widget for tqdm integration in Jupyter notebooks